### PR TITLE
.travis.yml: use go1.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.8
+  - 1.8.x
   - tip
   - master
 


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>