### PR TITLE
Reserve the MCS Level if the caller overrides the default.

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -49,8 +49,10 @@ func InitLabels(options []string) (string, string, error) {
 				mcon[con[0]] = con[1]
 			}
 		}
+		_ = ReleaseLabel(processLabel)
 		processLabel = pcon.Get()
 		mountLabel = mcon.Get()
+		_ = ReserveLabel(processLabel)
 	}
 	return processLabel, mountLabel, nil
 }


### PR DESCRIPTION
If a caller to label.InitLabels specifies a Level, then the library
leaks one Reserved level, and also fails to Reserve the specified level.

This could lead to a potential allocation of a duplicate level which would
eliminate the SELinux separation between two containers.

This patch eliminates the leak and correctly reserves the new level.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>