### PR TITLE
Add interface to determine if selinux is enabled on the host.

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -34,7 +34,7 @@ func InitLabels(options []string) (string, string, error) {
 		mcon := selinux.NewContext(mountLabel)
 		for _, opt := range options {
 			if opt == "disable" {
-				return "", "", nil
+				return "", mountLabel, nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
 				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -41,7 +41,7 @@ func TestInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if plabel != "user_u:user_r:user_t:s0:c1,c15" || (mlabel != "user_u:object_r:container_file_t:s0:c1,c15" && mlabel != "user_u:object_r:svirt_sandbox_file_t:s0:c1,c15") {
-		t.Log("InitLabels User Match Failed")
+		t.Logf("InitLabels User Match Failed %s, %s", plabel, mlabel)
 		t.Log(plabel, mlabel)
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This will allow container runtimes to differentiate whether SELinux is disabled
for the runtime versus disabled for the host system.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>