### PR TITLE
Support SELinux systems without MCS Labels

### DIFF
--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -41,7 +41,7 @@ func TestInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if plabel != "user_u:user_r:user_t:s0:c1,c15" || (mlabel != "user_u:object_r:container_file_t:s0:c1,c15" && mlabel != "user_u:object_r:svirt_sandbox_file_t:s0:c1,c15") {
-		t.Log("InitLabels User Match Failed")
+		t.Logf("InitLabels User Match Failed %s, %s", plabel, mlabel)
 		t.Log(plabel, mlabel)
 		t.Fatal(err)
 	}
@@ -143,4 +143,19 @@ func TestIsShared(t *testing.T) {
 		t.Fatalf("Expected label `Zz` to be shared, got %v", shared)
 	}
 
+}
+
+func TestSELinuxNoLevel(t *testing.T) {
+	if !selinux.GetEnabled() {
+		return
+	}
+	tlabel := "system_u:system_r:container_t"
+	dup := DupSecOpt(tlabel)
+	if len(dup) != 3 {
+		t.Errorf("DupSecOpt Failed on non mls label")
+	}
+	con := selinux.NewContext(tlabel)
+	if con.Get() != tlabel {
+		t.Errorf("NewContaxt and con.Get() Failed on non mls label")
+	}
 }

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -310,7 +310,10 @@ func SetExecLabel(label string) error {
 
 // Get returns the Context as a string
 func (c Context) Get() string {
-	return fmt.Sprintf("%s:%s:%s:%s", c["user"], c["role"], c["type"], c["level"])
+	if c["level"] != "" {
+		return fmt.Sprintf("%s:%s:%s:%s", c["user"], c["role"], c["type"], c["level"])
+	}
+	return fmt.Sprintf("%s:%s:%s", c["user"], c["role"], c["type"])
 }
 
 // NewContext creates a new Context struct from the specified label
@@ -322,7 +325,9 @@ func NewContext(label string) Context {
 		c["user"] = con[0]
 		c["role"] = con[1]
 		c["type"] = con[2]
-		c["level"] = con[3]
+		if len(con) > 3 {
+			c["level"] = con[3]
+		}
 	}
 	return c
 }
@@ -331,7 +336,9 @@ func NewContext(label string) Context {
 func ReserveLabel(label string) {
 	if len(label) != 0 {
 		con := strings.SplitN(label, ":", 4)
-		mcsAdd(con[3])
+		if len(con) > 3 {
+			mcsAdd(con[3])
+		}
 	}
 }
 
@@ -379,6 +386,9 @@ func DefaultEnforceMode() int {
 }
 
 func mcsAdd(mcs string) error {
+	if mcs == "" {
+		return nil
+	}
 	state.Lock()
 	defer state.Unlock()
 	if state.mcsList[mcs] {
@@ -389,6 +399,9 @@ func mcsAdd(mcs string) error {
 }
 
 func mcsDelete(mcs string) {
+	if mcs == "" {
+		return
+	}
 	state.Lock()
 	defer state.Unlock()
 	state.mcsList[mcs] = false
@@ -449,7 +462,9 @@ Allowing it to be used by another process.
 func ReleaseLabel(label string) {
 	if len(label) != 0 {
 		con := strings.SplitN(label, ":", 4)
-		mcsDelete(con[3])
+		if len(con) > 3 {
+			mcsDelete(con[3])
+		}
 	}
 }
 
@@ -522,13 +537,15 @@ func ContainerLabels() (processLabel string, fileLabel string) {
 		roFileLabel = fileLabel
 	}
 exit:
-	mcs := uniqMcs(1024)
 	scon := NewContext(processLabel)
-	scon["level"] = mcs
-	processLabel = scon.Get()
-	scon = NewContext(fileLabel)
-	scon["level"] = mcs
-	fileLabel = scon.Get()
+	if scon["level"] != "" {
+		mcs := uniqMcs(1024)
+		scon["level"] = mcs
+		processLabel = scon.Get()
+		scon = NewContext(fileLabel)
+		scon["level"] = mcs
+		fileLabel = scon.Get()
+	}
 	return processLabel, fileLabel
 }
 
@@ -601,14 +618,19 @@ func DupSecOpt(src string) []string {
 	con := NewContext(src)
 	if con["user"] == "" ||
 		con["role"] == "" ||
-		con["type"] == "" ||
-		con["level"] == "" {
+		con["type"] == "" {
 		return nil
 	}
-	return []string{"user:" + con["user"],
+	dup := []string{"user:" + con["user"],
 		"role:" + con["role"],
 		"type:" + con["type"],
-		"level:" + con["level"]}
+	}
+
+	if con["level"] != "" {
+		dup = append(dup, "level:"+con["level"])
+	}
+
+	return dup
 }
 
 // DisableSecOpt returns a security opt that can be used to disabling SELinux


### PR DESCRIPTION
Certain SELinux systems are compiled without MLS/MCS Support.
This means they don't support the level field in the SELinux
label.  Without this field you can not get MCS Separation for
your containers, but you can still use type enforcement.  This
patch allows the SELinux library to work on machines without MCS/MLS enabled.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>