### PR TITLE
fix selinufsMagic definition to work on 32 bit systems

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -106,7 +106,7 @@ func verifySELinuxfsMount(mnt string) bool {
 		}
 		return false
 	}
-	if buf.Type != selinuxfsMagic {
+	if uint32(buf.Type) != uint32(selinuxfsMagic) {
 		return false
 	}
 	if (buf.Flags & stRdOnly) != 0 {


### PR DESCRIPTION
Need to cast selinuxfsMagic and buf.Type to uint32 so it will work
on both 64 bit and 32 bit systems

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>