### PR TITLE
SELinux needs to be able to reset process label to ""

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -87,9 +87,6 @@ func FormatMountLabel(src, mountLabel string) string {
 // SetProcessLabel takes a process label and tells the kernel to assign the
 // label to the next program executed by the current process.
 func SetProcessLabel(processLabel string) error {
-	if processLabel == "" {
-		return nil
-	}
 	return selinux.SetExecLabel(processLabel)
 }
 


### PR DESCRIPTION
When program calls SetProcessLabel("") this is the equivalent to

setexeccon(NULL) in C, it sets the label of the next exec process to
the default transition.  Currently we are ignoring this call which is
wrong.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>