### PR TITLE
Add additional directories to block global relabel.

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -130,7 +130,7 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		return nil
 	}
 
-	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true}
+	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true, "/tmp": true, "/home": true, "/run": true, "/var": true, "/root": true}
 	if exclude_paths[path] {
 		return fmt.Errorf("SELinux relabeling of %s is not allowed", path)
 	}


### PR DESCRIPTION
I have a few bug reports where people have relabeled /tmp using

--volume /tmp:/tmp:z

Expanding the /* directories to block relabeling, to help uers from
shooting themselves in the foot.

The directories added can have multiple different labels in them and confined
domains need those labels.  If the user causes a contianer runtime to relabel
the content to container_file_t, then loots of confined domains start breaking.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>