### PR TITLE
Release SELinux labels on error in init function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.8.x
-  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
   - master
 
@@ -10,7 +10,7 @@ env:
     - BUILDTAGS="selinux"
 
 before_install:
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go get -u github.com/vbatts/git-validation
 
 script:

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -24,17 +24,22 @@ var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be use
 // the container.  A list of options can be passed into this function to alter
 // the labels.  The labels returned will include a random MCS String, that is
 // guaranteed to be unique.
-func InitLabels(options []string) (string, string, error) {
+func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 	if !selinux.GetEnabled() {
 		return "", "", nil
 	}
 	processLabel, mountLabel := selinux.ContainerLabels()
 	if processLabel != "" {
+		defer func() {
+			if Err != nil {
+				ReleaseLabel(mountLabel)
+			}
+		}()
 		pcon := selinux.NewContext(processLabel)
 		mcon := selinux.NewContext(mountLabel)
 		for _, opt := range options {
 			if opt == "disable" {
-				return "", "", nil
+				return "", mountLabel, nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
 				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)


### PR DESCRIPTION
Currently if we have an error in the options, we will leak and allocated
SELinux label.  This change will release on error.

Also return the mountlabel, even if the user specifies to disable SELinux separation.  This keeps other containers from being able to look at this privileged
containers content, as well makeing sure all content has a label.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>