### PR TITLE
Chcon: ignore ENOENT on recursive relabelling

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -687,7 +687,11 @@ func Chcon(fpath string, label string, recurse bool) error {
 		return err
 	}
 	callback := func(p string, info os.FileInfo, err error) error {
-		return SetFileLabel(p, label)
+		e := SetFileLabel(p, label)
+		if os.IsNotExist(e) {
+			return nil
+		}
+		return e
 	}
 
 	if recurse {


### PR DESCRIPTION
The file could be already deleted/moved by the time we are going to
relabel it.

Closes: https://github.com/containers/libpod/issues/1739

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>