### PR TITLE
Verify labels when user passes them in

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -75,8 +75,8 @@ func ReleaseLabel(label string) error {
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) []string {
-	return nil
+func DupSecOpt(src string) ([]string, error) {
+	return nil, nil
 }
 
 // DisableSecOpt returns a security opt that can disable labeling

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -35,8 +35,15 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 				ReleaseLabel(mountLabel)
 			}
 		}()
-		pcon := selinux.NewContext(processLabel)
-		mcon := selinux.NewContext(mountLabel)
+		pcon, err := selinux.NewContext(processLabel)
+		if err != nil {
+			return "", "", err
+		}
+
+		mcon, err := selinux.NewContext(mountLabel)
+		if err != nil {
+			return "", "", err
+		}
 		for _, opt := range options {
 			if opt == "disable" {
 				return "", mountLabel, nil
@@ -152,7 +159,11 @@ func Relabel(path string, fileLabel string, shared bool) error {
 	}
 
 	if shared {
-		c := selinux.NewContext(fileLabel)
+		c, err := selinux.NewContext(fileLabel)
+		if err != nil {
+			return err
+		}
+
 		c["level"] = "s0"
 		fileLabel = c.Get()
 	}
@@ -195,7 +206,7 @@ func ReleaseLabel(label string) error {
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) []string {
+func DupSecOpt(src string) ([]string, error) {
 	return selinux.DupSecOpt(src)
 }
 

--- a/go-selinux/label/label_selinux_stub_test.go
+++ b/go-selinux/label/label_selinux_stub_test.go
@@ -3,6 +3,7 @@
 package label
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -37,8 +38,8 @@ func TestInit(t *testing.T) {
 }
 
 func TestRelabel(t *testing.T) {
-	testdir := "/tmp/test"
-	if err := os.Mkdir(testdir, 0755); err != nil {
+	testdir, err := ioutil.TempDir("/tmp", "")
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(testdir)

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -3,6 +3,7 @@
 package label
 
 import (
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -53,7 +54,10 @@ func TestInit(t *testing.T) {
 	}
 }
 func TestDuplicateLabel(t *testing.T) {
-	secopt := DupSecOpt("system_u:system_r:container_t:s0:c1,c2")
+	secopt, err := DupSecOpt("system_u:system_r:container_t:s0:c1,c2")
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, opt := range secopt {
 		con := strings.SplitN(opt, ":", 2)
 		if con[0] == "user" {
@@ -91,8 +95,8 @@ func TestRelabel(t *testing.T) {
 	if !selinux.GetEnabled() {
 		return
 	}
-	testdir := "/tmp/test"
-	if err := os.Mkdir(testdir, 0755); err != nil {
+	testdir, err := ioutil.TempDir("/tmp", "")
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(testdir)
@@ -150,11 +154,18 @@ func TestSELinuxNoLevel(t *testing.T) {
 		return
 	}
 	tlabel := "system_u:system_r:container_t"
-	dup := DupSecOpt(tlabel)
+	dup, err := DupSecOpt(tlabel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if len(dup) != 3 {
 		t.Errorf("DupSecOpt Failed on non mls label")
 	}
-	con := selinux.NewContext(tlabel)
+	con, err := selinux.NewContext(tlabel)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if con.Get() != tlabel {
 		t.Errorf("NewContaxt and con.Get() Failed on non mls label")
 	}

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -115,9 +115,9 @@ func (c Context) Get() string {
 }
 
 // NewContext creates a new Context struct from the specified label
-func NewContext(label string) Context {
+func NewContext(label string) (Context, error) {
 	c := make(Context)
-	return c
+	return c, nil
 }
 
 // ClearLabels clears all reserved MLS/MCS levels
@@ -195,8 +195,8 @@ func Chcon(fpath string, label string, recurse bool) error {
 
 // DupSecOpt takes an SELinux process label and returns security options that
 // can be used to set the SELinux Type and Level for future container processes.
-func DupSecOpt(src string) []string {
-	return nil
+func DupSecOpt(src string) ([]string, error) {
+	return nil, nil
 }
 
 // DisableSecOpt returns a security opt that can be used to disable SELinux

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -59,7 +59,10 @@ func TestSELinux(t *testing.T) {
 	if _, err := SocketLabel(); err != nil {
 		t.Fatal(err)
 	}
-	con := NewContext("foobar")
+	con, err := NewContext("foobar")
+	if err != nil {
+		t.Fatal(err)
+	}
 	con.Get()
 	if err := SetEnforceMode(1); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Return errors on calls to NewContext and DupSecOpt when the user
passes in an SELinux label with less then three fields.

Currently this library will crash, when users pass in bad data.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>