### PR TITLE
Expand the list of relabel exclude paths

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -4,6 +4,8 @@ package label
 
 import (
 	"fmt"
+	"os"
+	"os/user"
 	"strings"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -146,7 +148,46 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		return nil
 	}
 
-	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true, "/tmp": true, "/home": true, "/run": true, "/var": true, "/root": true}
+	exclude_paths := map[string]bool{
+		"/":           true,
+		"/bin":        true,
+		"/boot":       true,
+		"/dev":        true,
+		"/etc":        true,
+		"/etc/passwd": true,
+		"/etc/pki":    true,
+		"/etc/shadow": true,
+		"/home":       true,
+		"/lib":        true,
+		"/lib64":      true,
+		"/media":      true,
+		"/opt":        true,
+		"/proc":       true,
+		"/root":       true,
+		"/run":        true,
+		"/sbin":       true,
+		"/srv":        true,
+		"/sys":        true,
+		"/tmp":        true,
+		"/usr":        true,
+		"/var":        true,
+		"/var/lib":    true,
+		"/var/log":    true,
+	}
+
+	if home := os.Getenv("HOME"); home != "" {
+		exclude_paths[home] = true
+	}
+
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if usr, err := user.Lookup(sudoUser); err == nil {
+			exclude_paths[usr.HomeDir] = true
+		}
+	}
+
+	if path != "/" {
+		path = strings.TrimSuffix(path, "/")
+	}
 	if exclude_paths[path] {
 		return fmt.Errorf("SELinux relabeling of %s is not allowed", path)
 	}

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -115,8 +115,18 @@ func TestRelabel(t *testing.T) {
 	if err := Relabel("/usr", label, false); err == nil {
 		t.Fatalf("Relabel /usr succeeded")
 	}
+	if err := Relabel("/usr/", label, false); err == nil {
+		t.Fatalf("Relabel /usr/ succeeded")
+	}
+	if err := Relabel("/etc/passwd", label, false); err == nil {
+		t.Fatalf("Relabel /etc/passwd succeeded")
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		if err := Relabel(home, label, false); err == nil {
+			t.Fatalf("Relabel %s succeeded", home)
+		}
+	}
 }
-
 func TestValidate(t *testing.T) {
 	if err := Validate("zZ"); err != ErrIncompatibleLabel {
 		t.Fatalf("Expected incompatible error, got %v", err)


### PR DESCRIPTION
Add additional paths that we want to prevent users from accidently relabeling.

Including all paths in /, and users home directories.  Also added security
files in /etc and a couple of other common paths.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>