### PR TITLE
fixing Code of Conduct link (per OCI call)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Please see the [godoc](https://godoc.org/github.com/opencontainers/selinux) for 
 
 ## Code of Conduct
 
-Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct](code-of-conduct).
+Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct][code-of-conduct].
 
 ## Security
 
 If you find an issue, please follow the [security][security] protocol to report it.
 
 [security]: https://github.com/opencontainers/org/blob/master/security
-[code-of-conduct]: https://github.com/opencontainers/org/blob/master/.github/CODE_OF_CONDUCT.md
+[code-of-conduct]: https://github.com/opencontainers/org/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

Per the OCI call, it was decided to move the code of conduct file into the root of the repository. This PR will fix the location, along with the top link to it.