### PR TITLE
Add interfaces to setup kernel keyring labeling

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -37,6 +37,14 @@ func SocketLabel() (string, error) {
 	return "", nil
 }
 
+func SetKeyLabel(processLabel string) error {
+	return nil
+}
+
+func KeyLabel() (string, error) {
+	return "", nil
+}
+
 func FileLabel(path string) (string, error) {
 	return "", nil
 }

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -115,6 +115,17 @@ func SocketLabel() (string, error) {
 	return selinux.SocketLabel()
 }
 
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(processLabel string) error {
+	return selinux.SetKeyLabel(processLabel)
+}
+
+// KeyLabel retrieves the current default kernel keyring label setting
+func KeyLabel() (string, error) {
+	return selinux.KeyLabel()
+}
+
 // ProcessLabel returns the process label that the kernel will assign
 // to the next program executed by the current process.  If "" is returned
 // this indicates that the default labeling will happen for the process.

--- a/go-selinux/label/label_selinux_stub_test.go
+++ b/go-selinux/label/label_selinux_stub_test.go
@@ -59,6 +59,16 @@ func TestSocketLabel(t *testing.T) {
 	}
 }
 
+func TestKeyLabel(t *testing.T) {
+	label := "system_u:object_r:container_t:s0:c1,c2"
+	if err := SetKeyLabel(label); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := KeyLabel(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestProcessLabel(t *testing.T) {
 	label := "system_u:object_r:container_t:s0:c1,c2"
 	if err := SetProcessLabel(label); err != nil {

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -197,3 +197,20 @@ func TestSocketLabel(t *testing.T) {
 		t.Errorf("SocketLabel %s != %s", nlabel, label)
 	}
 }
+
+func TestKeyLabel(t *testing.T) {
+	if !selinux.GetEnabled() {
+		return
+	}
+	label := "system_u:object_r:container_t:s0:c1,c2"
+	if err := selinux.SetKeyLabel(label); err != nil {
+		t.Fatal(err)
+	}
+	nlabel, err := selinux.KeyLabel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if label != nlabel {
+		t.Errorf("KeyLabel %s != %s", nlabel, label)
+	}
+}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -398,6 +398,17 @@ func SocketLabel() (string, error) {
 	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/sockcreate", syscall.Gettid()))
 }
 
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(label string) error {
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/keycreate", syscall.Gettid()), label)
+}
+
+// KeyLabel retrieves the current kernel keyring label setting
+func KeyLabel() (string, error) {
+	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/keycreate", syscall.Gettid()))
+}
+
 // Get returns the Context as a string
 func (c Context) Get() string {
 	if c["level"] != "" {

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -109,6 +109,17 @@ func SocketLabel() (string, error) {
 	return "", nil
 }
 
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(label string) error {
+	return nil
+}
+
+// KeyLabel retrieves the current kernel keyring label setting
+func KeyLabel() (string, error) {
+	return "", nil
+}
+
 // Get returns the Context as a string
 func (c Context) Get() string {
 	return ""

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -59,6 +59,12 @@ func TestSELinux(t *testing.T) {
 	if _, err := SocketLabel(); err != nil {
 		t.Fatal(err)
 	}
+	if err := SetKeyLabel("foobar"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := KeyLabel(); err != nil {
+		t.Fatal(err)
+	}
 	con, err := NewContext("foobar")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Kernel keyring patches in the kernel might allow us to
use kernel keyring with containers.  This patch allows us
to start labeling the kernel keyring to match the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>