### PR TITLE
Need to set process attributes not task

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -401,12 +401,12 @@ func SocketLabel() (string, error) {
 // SetKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
 func SetKeyLabel(label string) error {
-	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/keycreate", syscall.Gettid()), label)
+	return writeCon("/proc/self/attr/keycreate", label)
 }
 
 // KeyLabel retrieves the current kernel keyring label setting
 func KeyLabel() (string, error) {
-	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/keycreate", syscall.Gettid()))
+	return readCon("/proc/self/attr/keycreate")
 }
 
 // Get returns the Context as a string


### PR DESCRIPTION
The current setting of the kernel is failing to set the kernel keyring
within runc.  Changing to setting the process field instead of the
thread field seems to have fixed the issue.  With this change runc
is labeling the kernel keyring correctly so that it can be used within
the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>