### PR TITLE
Ignore attempts to setLabels "" on SELinux disabled systems

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -333,6 +333,11 @@ func writeCon(fpath string, val string) error {
 	if fpath == "" {
 		return ErrEmptyPath
 	}
+	if val == "" {
+		if !GetEnabled() {
+			return nil
+		}
+	}
 
 	out, err := os.OpenFile(fpath, os.O_WRONLY, 0)
 	if err != nil {


### PR DESCRIPTION
Some users of go-selinux attempt to set the SELinux label to ""
even on SELinux disabled systems. This can cause these apps to blow
up (runc).  Rather then complicated these tools API, we can just ignore
the attempts to set "" labels.

If the caller attempts to set a label != "", then we should continue to
attempt and fail appropriately.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>