### PR TITLE
fix can't use empty str as label in some old kernels

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -25,6 +25,10 @@ func SetProcessLabel(processLabel string) error {
 	return nil
 }
 
+func ClearProcessLabel() error {
+	return nil
+}
+
 func ProcessLabel() (string, error) {
 	return "", nil
 }
@@ -38,6 +42,10 @@ func SocketLabel() (string, error) {
 }
 
 func SetKeyLabel(processLabel string) error {
+	return nil
+}
+
+func ClearKeyLabel() error {
 	return nil
 }
 

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -101,7 +101,15 @@ func FormatMountLabel(src, mountLabel string) string {
 // SetProcessLabel takes a process label and tells the kernel to assign the
 // label to the next program executed by the current process.
 func SetProcessLabel(processLabel string) error {
+	if processLabel == "" && selinux.GetEnabled() {
+		processLabel = "unconfined_u:unconfined_r:unconfined_t:s0"
+	}
 	return selinux.SetExecLabel(processLabel)
+}
+
+// ClearProcessLabel is to clear process's label
+func ClearProcessLabel() error {
+	return selinux.SetExecLabel("unconfined_u:unconfined_r:unconfined_t:s0")
 }
 
 // SetSocketLabel takes a process label and tells the kernel to assign the
@@ -118,7 +126,15 @@ func SocketLabel() (string, error) {
 // SetKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
 func SetKeyLabel(processLabel string) error {
+	if processLabel == "" && selinux.GetEnabled() {
+		processLabel = "unconfined_u:unconfined_r:unconfined_t:s0"
+	}
 	return selinux.SetKeyLabel(processLabel)
+}
+
+// ClearKeyLabel is to clear key label
+func ClearKeyLabel() error {
+	return selinux.SetKeyLabel("unconfined_u:unconfined_r:unconfined_t:s0")
 }
 
 // KeyLabel retrieves the current default kernel keyring label setting

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -333,11 +333,6 @@ func writeCon(fpath string, val string) error {
 	if fpath == "" {
 		return ErrEmptyPath
 	}
-	if val == "" {
-		if !GetEnabled() {
-			return nil
-		}
-	}
 
 	out, err := os.OpenFile(fpath, os.O_WRONLY, 0)
 	if err != nil {
@@ -349,6 +344,10 @@ func writeCon(fpath string, val string) error {
 		_, err = out.Write([]byte(val))
 	} else {
 		_, err = out.Write(nil)
+	}
+	// for some kernels, we can't write "" as label.
+	if val == "" {
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
Signed-off-by: lifubang <lifubang@acmcoder.com>

In some old kernels, for example, `3.10.0-862.el7.x86_64` in `RedHat Enterprise Linux 7.5`.
Docker in this kernel works very well.
While the docker version is:
`docker-ce=3:18.09.4-3.el7` with `containerd=1.2.5-3.1.el7`.

But runc in master version works fail:
If we use empty string as a label, it will fail:
`write /proc/self/attr/keycreate: permission denied`
It will cause `runc` fail.

If the label is not empty, it will success. 