### PR TITLE
go-selinux/SetKeyLabel: fix for RHEL7 kernels

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -410,7 +410,7 @@ func SetKeyLabel(label string) error {
 	if os.IsNotExist(err) {
 		return nil
 	}
-	if label == "" && os.IsPermission(err) && !GetEnabled() {
+	if label == "" && os.IsPermission(err) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
As it was pointed out earlier, on a freshly installed CentOS 7
system (kernel 3.10.0-957.12.2.el7.x86_64) with SELinux enabled,
the kernel does not allow to write an empty label to the keycreate
file. Here's an strace except from containerd (which uses runc
which uses go-selinux):

> 20396 openat(AT_FDCWD, "/proc/self/attr/keycreate", O_WRONLY|O_CLOEXEC) = 7
> ...
> 20396 write(7, "", 0)                   = -1 EACCES (Permission denied)

NOTE: upgrading or downgrading container-selinux makes this to go
away, so in order to reproduce you need a freshly booted system.

Here is a reproducer in C:
```
[root@kir-ce7-selinux-01 ~]# cat a.c
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>

int main(void) {
	int fd, r;

	fd = open("/proc/self/attr/keycreate", O_WRONLY);
	if (fd < 0) {
		perror("open");
	}

	r = write(fd, "", 0);
	if (r < 0) {
		perror("write");
	}

	return 0;
}

[root@kir-ce7-selinux-01 ~]# uname -a
Linux kir-ce7-selinux-01 3.10.0-957.12.2.el7.x86_64 #1 SMP Tue May 14 21:24:32 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

[root@kir-ce7-selinux-01 ~]# gcc -Wall -O2 -o a a.c

[root@kir-ce7-selinux-01 ~]# ./a
write: Permission denied
[root@kir-ce7-selinux-01 ~]# strace ./a
...
open("/proc/self/attr/keycreate", O_WRONLY) = 3
write(3, "", 0)                         = -1 EACCES (Permission denied)
...
```

So, this is presumably a kernel bug, but since there is no update
available for this kernel, we have to modify the earlier workaround
(see commit d75cf62e6992fb) to NOT take into account whether
SELinux is enabled or not.

This fixes non-working docker/containerd/runc on CentOS 7 (and,
presumably, RHEL 7, too).

See also: https://github.com/opencontainers/selinux/pull/52, https://github.com/opencontainers/runc/pull/2033