### PR TITLE
Allow users to specify file types was well as process types

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -13,11 +13,12 @@ import (
 
 // Valid Label Options
 var validOptions = map[string]bool{
-	"disable": true,
-	"type":    true,
-	"user":    true,
-	"role":    true,
-	"level":   true,
+	"disable":  true,
+	"type":     true,
+	"filetype": true,
+	"user":     true,
+	"role":     true,
+	"level":    true,
 }
 
 var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be used together")
@@ -51,12 +52,15 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 				return "", mountLabel, nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
 			}
 			con := strings.SplitN(opt, ":", 2)
 			if !validOptions[con[0]] {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type'", con[0])
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
 
+			}
+			if con[0] == "filetype" {
+				mcon["type"] = con[1]
 			}
 			pcon[con[0]] = con[1]
 			if con[0] == "level" || con[0] == "user" {

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -53,6 +53,7 @@ func TestInit(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
 func TestDuplicateLabel(t *testing.T) {
 	secopt, err := DupSecOpt("system_u:system_r:container_t:s0:c1,c2")
 	if err != nil {
@@ -212,5 +213,21 @@ func TestKeyLabel(t *testing.T) {
 	}
 	if label != nlabel {
 		t.Errorf("KeyLabel %s != %s", nlabel, label)
+	}
+}
+
+func TestFileLabel(t *testing.T) {
+	if !selinux.GetEnabled() {
+		return
+	}
+	testUser := []string{"filetype:test_file_t", "level:s0:c1,c15"}
+	_, mlabel, err := InitLabels(testUser)
+	if err != nil {
+		t.Log("InitLabels User Failed")
+		t.Fatal(err)
+	}
+	if mlabel != "system_u:object_r:test_file_t:s0:c1,c15" {
+		t.Log("InitLabels filetype Failed")
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
More advanced policy is going to add different file types as well
as process types.  This change allows users to specify a filetype
field when initilizing the SELinux types to use.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>