### PR TITLE
selinux: verify that writes to /proc/... are on procfs

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -253,6 +254,12 @@ func getSELinuxPolicyRoot() string {
 	return filepath.Join(selinuxDir, readConfig(selinuxTypeTag))
 }
 
+func isProcHandle(fh *os.File) (bool, error) {
+	var buf unix.Statfs_t
+	err := unix.Fstatfs(int(fh.Fd()), &buf)
+	return buf.Type == unix.PROC_SUPER_MAGIC, err
+}
+
 func readCon(fpath string) (string, error) {
 	if fpath == "" {
 		return "", ErrEmptyPath
@@ -263,6 +270,12 @@ func readCon(fpath string) (string, error) {
 		return "", err
 	}
 	defer in.Close()
+
+	if ok, err := isProcHandle(in); err != nil {
+		return "", err
+	} else if !ok {
+		return "", fmt.Errorf("%s not on procfs", fpath)
+	}
 
 	var retval string
 	if _, err := fmt.Fscanf(in, "%s", &retval); err != nil {
@@ -346,6 +359,12 @@ func writeCon(fpath string, val string) error {
 	}
 	defer out.Close()
 
+	if ok, err := isProcHandle(out); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("%s not on procfs", fpath)
+	}
+
 	if val != "" {
 		_, err = out.Write([]byte(val))
 	} else {
@@ -394,7 +413,7 @@ func SetExecLabel(label string) error {
 }
 
 /*
-SetTaskLabel sets the SELinux label for the current thread, or an error. 
+SetTaskLabel sets the SELinux label for the current thread, or an error.
 This requires the dyntransition permission.
 */
 func SetTaskLabel(label string) error {


### PR DESCRIPTION
This is an additional mitigation for CVE-2019-16884. The primary problem
is that Docker can be coerced into bind-mounting a file system on top of
/proc (resulting in label-related writes to /proc no longer happening).

While runc is working on mitigations against permitting the mounts, this
helps avoid go-selinux from being tricked into writing to non-procfs
files. This is not a perfect solution (after all, there might be a
bind-mount of a different procfs file over the target) but in order to
exploit that you would need to be able to tweak a config.json pretty
specifically (which thankfully Docker doesn't allow).

See opencontainers/runc#2128
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>