### PR TITLE
Fix EnforceMode, SetEnforceMode, and SecurityCheckContext

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -37,7 +37,6 @@ const (
 	selinuxTag       = "SELINUX"
 	xattrNameSelinux = "security.selinux"
 	stRdOnly         = 0x01
-	selinuxfsMagic   = 0xf97cff8c
 )
 
 type selinuxState struct {
@@ -118,7 +117,8 @@ func verifySELinuxfsMount(mnt string) bool {
 		}
 		return false
 	}
-	if uint32(buf.Type) != uint32(selinuxfsMagic) {
+
+	if buf.Type != unix.SELINUX_MAGIC {
 		return false
 	}
 	if (buf.Flags & stRdOnly) != 0 {

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -505,19 +506,18 @@ func ReserveLabel(label string) {
 }
 
 func selinuxEnforcePath() string {
-	return fmt.Sprintf("%s/enforce", getSelinuxMountPoint())
+	return path.Join(getSelinuxMountPoint(), "enforce")
 }
 
 // EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
 func EnforceMode() int {
 	var enforce int
 
-	enforceS, err := readCon(selinuxEnforcePath())
+	enforceB, err := ioutil.ReadFile(selinuxEnforcePath())
 	if err != nil {
 		return -1
 	}
-
-	enforce, err = strconv.Atoi(string(enforceS))
+	enforce, err = strconv.Atoi(string(enforceB))
 	if err != nil {
 		return -1
 	}
@@ -529,7 +529,7 @@ SetEnforceMode sets the current SELinux mode Enforcing, Permissive.
 Disabled is not valid, since this needs to be set at boot time.
 */
 func SetEnforceMode(mode int) error {
-	return writeCon(selinuxEnforcePath(), fmt.Sprintf("%d", mode))
+	return ioutil.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0644)
 }
 
 /*
@@ -711,7 +711,7 @@ exit:
 
 // SecurityCheckContext validates that the SELinux label is understood by the kernel
 func SecurityCheckContext(val string) error {
-	return writeCon(fmt.Sprintf("%s/context", getSelinuxMountPoint()), val)
+	return ioutil.WriteFile(path.Join(getSelinuxMountPoint(), "context"), []byte(val), 0644)
 }
 
 /*

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -53,9 +53,6 @@ func TestSELinux(t *testing.T) {
 	t.Log(plabel)
 	t.Log(flabel)
 	ReleaseLabel(plabel)
-	t.Log("Enforcing Mode", EnforceMode())
-	mode := DefaultEnforceMode()
-	t.Log("Default Enforce Mode ", mode)
 
 	plabel, flabel = ContainerLabels()
 	t.Log(plabel)
@@ -66,15 +63,6 @@ func TestSELinux(t *testing.T) {
 	t.Log(plabel)
 	t.Log(flabel)
 	ReleaseLabel(plabel)
-
-	defer SetEnforceMode(mode)
-	if err := SetEnforceMode(Enforcing); err != nil {
-		t.Fatalf("enforcing selinux failed: %v", err)
-	}
-	if err := SetEnforceMode(Permissive); err != nil {
-		t.Fatalf("setting selinux mode to permissive failed: %v", err)
-	}
-	SetEnforceMode(mode)
 
 	pid := os.Getpid()
 	t.Logf("PID:%d MCS:%s\n", pid, intToMcs(pid, 1023))
@@ -93,6 +81,27 @@ func TestSELinux(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(PidLabel(1))
+}
+
+func TestSetEnforceMode(t *testing.T) {
+	if !GetEnabled() {
+		t.Skip("SELinux not enabled, skipping.")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("root required, skipping")
+	}
+
+	t.Log("Enforcing Mode:", EnforceMode())
+	mode := DefaultEnforceMode()
+	t.Log("Default Enforce Mode:", mode)
+	defer SetEnforceMode(mode)
+
+	if err := SetEnforceMode(Enforcing); err != nil {
+		t.Fatalf("setting selinux mode to enforcing failed: %v", err)
+	}
+	if err := SetEnforceMode(Permissive); err != nil {
+		t.Fatalf("setting selinux mode to permissive failed: %v", err)
+	}
 }
 
 func TestCanonicalizeContext(t *testing.T) {

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -175,3 +175,28 @@ func TestFindSELinuxfsInMountinfo(t *testing.T) {
 		}
 	}
 }
+
+func TestSecurityCheckContext(t *testing.T) {
+	if !GetEnabled() {
+		t.Skip("SELinux not enabled, skipping.")
+	}
+
+	// check with valid context
+	context, err := CurrentLabel()
+	if err != nil {
+		t.Fatalf("CurrentLabel() error: %v", err)
+	}
+	if context != "" {
+		t.Logf("SecurityCheckContext(%q)", context)
+		err = SecurityCheckContext(context)
+		if err != nil {
+			t.Errorf("SecurityCheckContext(%q) error: %v", context, err)
+		}
+	}
+
+	context = "not-syntactically-valid"
+	err = SecurityCheckContext(context)
+	if err == nil {
+		t.Errorf("SecurityCheckContext(%q) succeeded, expected to fail", context)
+	}
+}


### PR DESCRIPTION
While working on minor improvements to tests, I found out
that `SetEnforceMode()` is not working even for the root user:

```
--- FAIL: TestSetEnforceMode (0.00s)
   selinux_linux_test.go:94: Enforcing Mode:  -1
   selinux_linux_test.go:96: Default Enforce Mode:  1
   selinux_linux_test.go:100: setting selinux mode to enforcing failed:
/sys/fs/selinux/enforce not on procfs
```
If you look closer, you'll see that `EnforceMode()` is not working either,
since it returns `-1`.

The problem is, these functions, as well as `SecurityCheckContext()`,
are using `readCon()` and `writeCon()`, which require the files
being read/written to be on `procfs`.

In these cases, though, the files are on `selinuxfs`, and the filesystem
check is not really required since we already checked that during
selinuxfs mount point search.

So, just use ioutil.ReadFile/WriteFile here.

While at it
- convert code to use `path.Join()` instead of `fmt.Sprintf()`
- add a test case for `SecurityCheckContext`

Other improvements in this PR:
* `TestSetEnforceMode`: separate and fix for non-root
* simplify `isProcHandle()` to only return an error (and therefore simplify its usage)
* improve errors from `isProcHandle` (and thus `readCon()`/`writeCon()`)
to provide file name in case of `fstatfs()` error
* `Remove SelinuxfsMagic` constant, use one from `x/sys/unix`.


@rhatdan @mrunalp @stephensmalley PTAL