### PR TITLE
getSELinuxfs: optimize/simplify using sync.Once

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -166,18 +166,18 @@ func findSELinuxfs() string {
 // if there is one, or an empty string in case of EOF or error.
 func findSELinuxfsMount(s *bufio.Scanner) string {
 	for s.Scan() {
-		txt := s.Text()
+		txt := s.Bytes()
 		// The first field after - is fs type.
 		// Safe as spaces in mountpoints are encoded as \040
-		if !strings.Contains(txt, " - selinuxfs ") {
+		if !bytes.Contains(txt, []byte(" - selinuxfs ")) {
 			continue
 		}
 		const mPos = 5 // mount point is 5th field
-		fields := strings.SplitN(txt, " ", mPos+1)
+		fields := bytes.SplitN(txt, []byte(" "), mPos+1)
 		if len(fields) < mPos+1 {
 			continue
 		}
-		return fields[mPos-1]
+		return string(fields[mPos-1])
 	}
 
 	return ""


### PR DESCRIPTION
Something I wanted to do 2 years ago (https://github.com/opencontainers/selinux/pull/26) but forgot :)

1. Optimize `findSELinuxfsMount()` a bit using `s.Bytes()` (less copying and garbage collecting)

2. Simplify `getSELinuxfs()` code using `sync.Once`. No functional change.