### PR TITLE
Complete syscall -> x/sys/unix switch, fix lgetxattr corner case

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -37,7 +36,6 @@ const (
 	selinuxTypeTag   = "SELINUXTYPE"
 	selinuxTag       = "SELINUX"
 	xattrNameSelinux = "security.selinux"
-	stRdOnly         = 0x01
 )
 
 type selinuxState struct {
@@ -103,13 +101,13 @@ func SetDisabled() {
 }
 
 func verifySELinuxfsMount(mnt string) bool {
-	var buf syscall.Statfs_t
+	var buf unix.Statfs_t
 	for {
-		err := syscall.Statfs(mnt, &buf)
+		err := unix.Statfs(mnt, &buf)
 		if err == nil {
 			break
 		}
-		if err == syscall.EAGAIN {
+		if err == unix.EAGAIN {
 			continue
 		}
 		return false
@@ -118,7 +116,7 @@ func verifySELinuxfsMount(mnt string) bool {
 	if buf.Type != unix.SELINUX_MAGIC {
 		return false
 	}
-	if (buf.Flags & stRdOnly) != 0 {
+	if (buf.Flags & unix.ST_RDONLY) != 0 {
 		return false
 	}
 
@@ -390,7 +388,7 @@ func attrPath(attr string) string {
 		return path.Join(threadSelfPrefix, attr)
 	}
 
-	return path.Join("/proc/self/task/", strconv.Itoa(syscall.Gettid()), "/attr/", attr)
+	return path.Join("/proc/self/task/", strconv.Itoa(unix.Gettid()), "/attr/", attr)
 }
 
 func readAttr(attr string) (string, error) {
@@ -461,7 +459,7 @@ func SocketLabel() (string, error) {
 
 // PeerLabel retrieves the label of the client on the other side of a socket
 func PeerLabel(fd uintptr) (string, error) {
-	return unix.GetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERSEC)
+	return unix.GetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_PEERSEC)
 }
 
 // SetKeyLabel takes a process label and tells the kernel to assign the

--- a/go-selinux/xattrs.go
+++ b/go-selinux/xattrs.go
@@ -12,8 +12,8 @@ func lgetxattr(path string, attr string) ([]byte, error) {
 	// Start with a 128 length byte array
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
-	if errno == unix.ERANGE {
-		// Buffer too small, get the real size first
+	for errno == unix.ERANGE {
+		// Buffer too small, use zero-sized buffer to get the actual size
 		sz, errno = unix.Lgetxattr(path, attr, []byte{})
 		if errno != nil {
 			return nil, errno


### PR DESCRIPTION
These two are really unrelated but since they are both very simple I combined both to this single PR.

1. Complete the switch to `x/sys/unix`, and remove own ST_RDONLY const.

2. Fix a corner case in lgetxattr.

    lgetxattr(2) man page says:
    
    > If size is specified as zero, these calls return the  current  size  of
    > the  named extended attribute (and leave value unchanged).  This can be
    > used to determine the size of the buffer that should be supplied  in  a
    > subsequent  call.   (But, bear in mind that there is a possibility that
    > the attribute value may change between the two calls,  so  that  it  is
    > still necessary to check the return status from the second call.)
    
    The current code does not handle the "But..." case, i.e. when the size
    changes between the two calls, and the new size is larger.
    
    Fix that.