### PR TITLE
Add uint32 cast to unix.SELINUX_MAGIC

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -115,7 +115,7 @@ func verifySELinuxfsMount(mnt string) bool {
 		return false
 	}
 
-	if buf.Type != unix.SELINUX_MAGIC {
+	if uint32(buf.Type) != uint32(unix.SELINUX_MAGIC) {
 		return false
 	}
 	if (buf.Flags & stRdOnly) != 0 {


### PR DESCRIPTION
Otherwise this value will be treated as `int32`, which results in an
build error in 386 environments:

```
selinux_linux.go:118:14: constant 4185718668 overflows int32
```