### PR TITLE
Add support for ComputeCreateContext and ClassIndex

### DIFF
--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -35,6 +35,11 @@ func GetEnabled() bool {
 	return false
 }
 
+// ClassIndex returns the int index for an object class in the loaded policy, or -1 and an error
+func ClassIndex(class string) (int, error) {
+	return -1, nil
+}
+
 // SetFileLabel sets the SELinux label for this path or returns an error.
 func SetFileLabel(fpath string, label string) error {
 	return nil
@@ -85,6 +90,13 @@ the function then returns the context that the kernel will use.  This function
 can be used to see if two contexts are equivalent
 */
 func CanonicalizeContext(val string) (string, error) {
+	return "", nil
+}
+
+/*
+ComputeCreateContext requests the type transition from source to target for class  from the kernel.
+*/
+func ComputeCreateContext(source string, target string, class string) (string, error) {
 	return "", nil
 }
 

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -56,13 +56,19 @@ func TestSELinux(t *testing.T) {
 	if _, err := CanonicalizeContext("foobar"); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := ComputeCreateContext("foo", "bar", "foobar"); err != nil {
+		t.Fatal(err)
+	}
 	if err := SetSocketLabel("foobar"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ClassIndex("foobar"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := SocketLabel(); err != nil {
 		t.Fatal(err)
 	}
-	if _,err := PeerLabel(0); err != nil {
+	if _, err := PeerLabel(0); err != nil {
 		t.Fatal(err)
 	}
 	if err := SetKeyLabel("foobar"); err != nil {


### PR DESCRIPTION
ComputeCreateContext is the same as compute_create in libselinux and takes
source context, target context, and class index and returns
the computed transition context. The class index can be retrieved
with ClassIndex().

Signed-off-by: Joshua Brindle <joshua.brindle@crunchydata.com>