### PR TITLE
Add pkg/pwalk, make Chcon() faster

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/opencontainers/selinux/pkg/pwalk"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -823,7 +824,7 @@ func Chcon(fpath string, label string, recurse bool) error {
 		return SetFileLabel(fpath, label)
 	}
 
-	return filepath.Walk(fpath, func(p string, info os.FileInfo, err error) error {
+	return pwalk.Walk(fpath, func(p string, info os.FileInfo, err error) error {
 		e := SetFileLabel(p, label)
 		// Walk a file tree can race with removal, so ignore ENOENT
 		if os.IsNotExist(errors.Cause(e)) {

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -805,8 +805,8 @@ func badPrefix(fpath string) error {
 	return nil
 }
 
-// Chcon changes the `fpath` file object to the SELinux label `label`.
-// If `fpath` is a directory and `recurse`` is true, Chcon will walk the
+// Chcon changes the fpath file object to the SELinux label label.
+// If fpath is a directory and recurse is true, Chcon will walk the
 // directory tree setting the label.
 func Chcon(fpath string, label string, recurse bool) error {
 	if fpath == "" {
@@ -818,19 +818,19 @@ func Chcon(fpath string, label string, recurse bool) error {
 	if err := badPrefix(fpath); err != nil {
 		return err
 	}
-	callback := func(p string, info os.FileInfo, err error) error {
+
+	if !recurse {
+		return SetFileLabel(fpath, label)
+	}
+
+	return filepath.Walk(fpath, func(p string, info os.FileInfo, err error) error {
 		e := SetFileLabel(p, label)
+		// Walk a file tree can race with removal, so ignore ENOENT
 		if os.IsNotExist(errors.Cause(e)) {
 			return nil
 		}
 		return e
-	}
-
-	if recurse {
-		return filepath.Walk(fpath, callback)
-	}
-
-	return SetFileLabel(fpath, label)
+	})
 }
 
 // DupSecOpt takes an SELinux process label and returns security options that

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -248,4 +249,21 @@ func TestComputeCreateContext(t *testing.T) {
 		t.Errorf("ComputeCreateContext(%s, %s, %s) succeeded, expected failure", badcon, tmp, process)
 	}
 
+}
+
+func BenchmarkChcon(b *testing.B) {
+	file, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		b.Fatalf("filepath.Abs: %v", err)
+	}
+	dir := filepath.Dir(file)
+	con, err := FileLabel(file)
+	if err != nil {
+		b.Fatalf("FileLabel(%q): %v", file, err)
+	}
+	b.Logf("Chcon(%q, %q)", dir, con)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		Chcon(dir, con, true)
+	}
 }

--- a/pkg/pwalk/README.md
+++ b/pkg/pwalk/README.md
@@ -1,0 +1,42 @@
+## pwalk: parallel implementation of filepath.Walk
+
+This is a wrapper for [filepath.Walk](https://pkg.go.dev/path/filepath?tab=doc#Walk)
+which may speed it up by calling multiple callback functions (WalkFunc) in parallel,
+utilizing goroutines.
+
+By default, it utilizes 2\*runtime.NumCPU() goroutines for callbacks.
+This can be changed by using WalkN function which has the additional
+parameter, specifying the number of goroutines (concurrency).
+
+### Caveats
+
+Please note the following limitations of this code:
+
+* Unlike filepath.Walk, the order of calls is non-deterministic;
+
+* Only primitive error handling is supported:
+
+  * filepath.SkipDir is not supported;
+
+  * no errors are ever passed to WalkFunc;
+
+  * once any error is returned from any WalkFunc instance, no more new calls
+    to WalkFunc are made, and the error is returned to the caller of Walk;
+
+  * if more than one walkFunc instance will return an error, only one
+    of such errors will be propagated and returned by Walk, others
+    will be silently discarded.
+
+### Documentation
+
+For the official documentation, see
+https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalk?tab=doc
+
+### Benchmarks
+
+For a WalkFunc that consists solely of the return statement, this
+implementation is about 10% slower than the standard library's
+filepath.Walk.
+
+Otherwise (if a WalkFunc is doing something) this is usually faster,
+except when the WalkN(..., 1) is used.

--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -1,0 +1,99 @@
+package pwalk
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type WalkFunc = filepath.WalkFunc
+
+// Walk is a wrapper for filepath.Walk which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// twice the runtime.NumCPU() walkFn will be called at any one time.
+// If you want to change the maximum, use WalkN instead.
+//
+// The order of calls is non-deterministic.
+//
+// Note that this implementation only supports primitive error handling:
+//
+// * no errors are ever passed to WalkFn
+//
+// * once a walkFn returns any error, all further processing stops
+//   and the error is returned to the caller of Walk;
+//
+// * filepath.SkipDir is not supported;
+//
+// * if more than one walkFn instance will return an error, only one
+//   of such errors will be propagated and returned by Walk, others
+//   will be silently discarded.
+//
+func Walk(root string, walkFn WalkFunc) error {
+	return WalkN(root, walkFn, runtime.NumCPU()*2)
+}
+
+// WalkN is a wrapper for filepath.Walk which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// num walkFn will be called at any one time.
+func WalkN(root string, walkFn WalkFunc, num int) error {
+	// make sure limit is sensible
+	if num < 1 {
+		return errors.Errorf("walk(%q): num must be > 0", root)
+	}
+
+	files := make(chan *walkArgs, 2*num)
+	errCh := make(chan error, 1) // get the first error, ignore others
+
+	// Start walking a tree asap
+	var err error
+	go func() {
+		err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				close(files)
+				return err
+			}
+			// add a file to the queue unless a callback sent an error
+			select {
+			case e := <-errCh:
+				close(files)
+				return e
+			default:
+				files <- &walkArgs{path: p, info: &info}
+				return nil
+			}
+		})
+		if err == nil {
+			close(files)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(num)
+	for i := 0; i < num; i++ {
+		go func() {
+			for file := range files {
+				if e := walkFn(file.path, *file.info, nil); e != nil {
+					select {
+					case errCh <- e: // sent ok
+					default: // buffer full
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	return err
+}
+
+// walkArgs holds the arguments that were passed to the Walk or WalkLimit
+// functions.
+type walkArgs struct {
+	path string
+	info *os.FileInfo
+}

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -1,0 +1,219 @@
+package pwalk
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestWalk(t *testing.T) {
+	var count uint32
+	concurrency := runtime.NumCPU() * 2
+
+	dir, total, err := prepareTestSet(3, 2, 1)
+	if err != nil {
+		t.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	err = WalkN(dir,
+		func(_ string, _ os.FileInfo, _ error) error {
+			atomic.AddUint32(&count, 1)
+			return nil
+		},
+		concurrency)
+
+	if err != nil {
+		t.Errorf("Walk failed: %v", err)
+	}
+	if count != uint32(total) {
+		t.Errorf("File count mismatch: found %d, expected %d", count, total)
+	}
+
+	t.Logf("concurrency: %d, files found: %d\n", concurrency, count)
+}
+
+func TestWalkManyErrors(t *testing.T) {
+	var count uint32
+
+	dir, total, err := prepareTestSet(3, 3, 2)
+	if err != nil {
+		t.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	max := uint32(total / 2)
+	e42 := errors.New("42")
+	err = Walk(dir,
+		func(p string, i os.FileInfo, _ error) error {
+			if atomic.AddUint32(&count, 1) > max {
+				return e42
+			}
+			return nil
+		})
+	t.Logf("found %d of %d files", count, total)
+
+	if err == nil {
+		t.Errorf("Walk succeeded, but error is expected")
+		if count != uint32(total) {
+			t.Errorf("File count mismatch: found %d, expected %d", count, total)
+		}
+	}
+}
+
+func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error) {
+	for d := 0; d < dirs; d++ {
+		var dir string
+		dir, err = ioutil.TempDir(prefix, "d-")
+		if err != nil {
+			return
+		}
+		count++
+		for f := 0; f < files; f++ {
+			fi, err := ioutil.TempFile(dir, "f-")
+			if err != nil {
+				return count, err
+			}
+			fi.Close()
+			count++
+		}
+		if levels == 0 {
+			continue
+		}
+		var c int
+		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
+			return
+		}
+		count += c
+	}
+
+	return
+}
+
+// prepareTestSet() creates a directory tree of shallow files,
+// to be used for testing or benchmarking.
+//
+// Total dirs: dirs^levels + dirs^(levels-1) + ... + dirs^1
+// Total files: total_dirs * files
+func prepareTestSet(levels, dirs, files int) (dir string, total int, err error) {
+	dir, err = ioutil.TempDir(".", "pwalk-test-")
+	if err != nil {
+		return
+	}
+	total, err = makeManyDirs(dir, levels, dirs, files)
+	if err != nil && total > 0 {
+		_ = os.RemoveAll(dir)
+		dir = ""
+		total = 0
+		return
+	}
+	total++ // this dir
+
+	return
+}
+
+type walkerFunc func(root string, walkFn WalkFunc) error
+
+func genWalkN(n int) walkerFunc {
+	return func(root string, walkFn WalkFunc) error {
+		return WalkN(root, walkFn, n)
+	}
+}
+
+func BenchmarkWalk(b *testing.B) {
+	const (
+		levels = 5 // how deep
+		dirs   = 3 // dirs on each levels
+		files  = 8 // files on each levels
+	)
+
+	benchmarks := []struct {
+		name string
+		walk filepath.WalkFunc
+	}{
+		{"Empty", cbEmpty},
+		{"ReadFile", cbReadFile},
+		{"ChownChmod", cbChownChmod},
+		{"RandomSleep", cbRandomSleep},
+	}
+
+	walkers := []struct {
+		name   string
+		walker walkerFunc
+	}{
+		{"filepath.Walk", filepath.Walk},
+		{"pwalk.Walk", Walk},
+		// test WalkN with various values of N
+		{"pwalk.Walk1", genWalkN(1)},
+		{"pwalk.Walk2", genWalkN(2)},
+		{"pwalk.Walk4", genWalkN(4)},
+		{"pwalk.Walk8", genWalkN(8)},
+		{"pwalk.Walk16", genWalkN(16)},
+		{"pwalk.Walk32", genWalkN(32)},
+		{"pwalk.Walk64", genWalkN(64)},
+		{"pwalk.Walk128", genWalkN(128)},
+		{"pwalk.Walk256", genWalkN(256)},
+	}
+
+	dir, total, err := prepareTestSet(levels, dirs, files)
+	if err != nil {
+		b.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	b.Logf("dataset: %d levels x %d dirs x %d files, total entries: %d", levels, dirs, files, total)
+
+	for _, bm := range benchmarks {
+		for _, w := range walkers {
+			walker := w.walker
+			walkFn := bm.walk
+			// preheat
+			err := w.walker(dir, bm.walk)
+			if err != nil {
+				b.Errorf("walk failed: %v", err)
+			}
+			// benchmark
+			b.Run(bm.name+"/"+w.name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					err := walker(dir, walkFn)
+					if err != nil {
+						b.Errorf("walk failed: %v", err)
+					}
+				}
+			})
+		}
+	}
+}
+func cbEmpty(_ string, _ os.FileInfo, _ error) error {
+	return nil
+}
+
+func cbChownChmod(path string, info os.FileInfo, _ error) error {
+	_ = os.Chown(path, 0, 0)
+	mode := os.FileMode(0644)
+	if info.Mode().IsDir() {
+		mode = os.FileMode(0755)
+	}
+	_ = os.Chmod(path, mode)
+
+	return nil
+}
+
+func cbReadFile(path string, info os.FileInfo, _ error) error {
+	var err error
+	if info.Mode().IsRegular() {
+		_, err = ioutil.ReadFile(path)
+	}
+	return err
+}
+
+func cbRandomSleep(_ string, _ os.FileInfo, _ error) error {
+	time.Sleep(time.Duration(rand.Intn(500)) * time.Microsecond)
+	return nil
+}


### PR DESCRIPTION
_This is a continuation of https://github.com/opencontainers/selinux/pull/85 and https://github.com/containers/common/pull/82_

**TL;DR:** This adds a parallel wrapper on top of `filetree.Walk()`, enabling multiple callbacks to be used concurrently. This is proven to speed things up. The resulting implementation is used for `Chcon()`, making it about 1.5x faster.

Please see more in commit messages. For previous discussions, see the abovementioned PRs.

NOTE that this is not as fast as https://github.com/opencontainers/selinux/pull/85. The reason is we use standard `filepath.Walk()` here, which performs the (unneeded) `os.Stat()` call on every entry, and also sorts the directory entries (which also does not make sense in many cases). So, yes, we can do better, but that means either another third-party package (such as github.com/karrick/godirwalk) or rewriting the filepath.Walk() from scratch. I'm still on the verge as whether we should do it, and am open to any suggestions.