### PR TITLE
Implement FormatMountLabel unconditionally

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -1,6 +1,8 @@
 package label
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
@@ -75,3 +77,21 @@ func ReleaseLabel(label string) error {
 // can be used to set duplicate labels on future container processes
 // Deprecated: use selinux.DupSecOpt
 var DupSecOpt = selinux.DupSecOpt
+
+// FormatMountLabel returns a string to be used by the mount command.
+// The format of this string will be used to alter the labeling of the mountpoint.
+// The string returned is suitable to be used as the options field of the mount command.
+// If you need to have additional mount point options, you can pass them in as
+// the first parameter.  Second parameter is the label that you wish to apply
+// to all content in the mount point.
+func FormatMountLabel(src, mountLabel string) string {
+	if mountLabel != "" {
+		switch src {
+		case "":
+			src = fmt.Sprintf("context=%q", mountLabel)
+		default:
+			src = fmt.Sprintf("%s,context=%q", src, mountLabel)
+		}
+	}
+	return src
+}

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -3,7 +3,6 @@
 package label
 
 import (
-	"fmt"
 	"os"
 	"os/user"
 	"strings"
@@ -80,24 +79,6 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 // to the official API. Use InitLabels(strings.Fields(options)) instead.
 func GenLabels(options string) (string, string, error) {
 	return InitLabels(strings.Fields(options))
-}
-
-// FormatMountLabel returns a string to be used by the mount command.
-// The format of this string will be used to alter the labeling of the mountpoint.
-// The string returned is suitable to be used as the options field of the mount command.
-// If you need to have additional mount point options, you can pass them in as
-// the first parameter.  Second parameter is the label that you wish to apply
-// to all content in the mount point.
-func FormatMountLabel(src, mountLabel string) string {
-	if mountLabel != "" {
-		switch src {
-		case "":
-			src = fmt.Sprintf("context=%q", mountLabel)
-		default:
-			src = fmt.Sprintf("%s,context=%q", src, mountLabel)
-		}
-	}
-	return src
 }
 
 // SetFileLabel modifies the "path" label to the specified file label

--- a/go-selinux/label/label_stub.go
+++ b/go-selinux/label/label_stub.go
@@ -15,10 +15,6 @@ func GenLabels(options string) (string, string, error) {
 	return "", "", nil
 }
 
-func FormatMountLabel(src string, mountLabel string) string {
-	return src
-}
-
 func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -83,13 +83,6 @@ func CheckLabelCompile(t *testing.T) {
 	if _, _, err := GenLabels(""); err != nil {
 		t.Fatal(err)
 	}
-	if test := FormatMountLabel("", ""); test != "" {
-		t.Fatal("Format failed")
-	}
-
-	if test := FormatMountLabel("", ""); test != "" {
-		t.Fatal("Format failed")
-	}
 
 	if _, err := FileLabel("/etc"); err != nil {
 		t.Fatal(err)

--- a/go-selinux/label/label_test.go
+++ b/go-selinux/label/label_test.go
@@ -1,0 +1,20 @@
+package label
+
+import "testing"
+
+func TestFormatMountLabel(t *testing.T) {
+	expected := `context="foobar"`
+	if test := FormatMountLabel("", "foobar"); test != expected {
+		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
+	}
+
+	expected = `src,context="foobar"`
+	if test := FormatMountLabel("src", "foobar"); test != expected {
+		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
+	}
+
+	expected = `src`
+	if test := FormatMountLabel("src", ""); test != expected {
+		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
+	}
+}


### PR DESCRIPTION
Implementing FormatMountLabel on situations built without selinux should be possible; the `context` will be ignored if no SELinux is available.
