### PR TITLE
Fix CheckLabelCompile not running as test

### DIFF
--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -79,7 +79,7 @@ func TestProcessLabel(t *testing.T) {
 	}
 }
 
-func CheckLabelCompile(t *testing.T) {
+func TestCheckLabelCompile(t *testing.T) {
 	if _, _, err := GenLabels(""); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The function did not have `Test` as prefix, so wouldn't
be run when running tests.