### PR TITLE
Remote potential race condition, where mcs label is freed

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -48,7 +48,7 @@ var PidLabel = selinux.PidLabel
 
 // Init initialises the labeling system
 func Init() {
-	selinux.GetEnabled()
+	_ = selinux.GetEnabled()
 }
 
 // ClearLabels will clear all reserved labels


### PR DESCRIPTION
Theorectially if you do not change the MCS Label then we free it and two
commands later reserve it.  If some other process was grabbing MCS Labels
at the same time, the other process could get the same label.

Now we only release the label, if we have changed the MCSlevel.

Coverity was complaining about the selinux.GetEnabled() not being checked.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>