### PR TITLE
Allow the category range to be changed

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -31,6 +31,9 @@ const (
 	// Disabled constant to indicate SELinux is disabled
 	Disabled = -1
 
+	// DefaultCategoryRange is the upper bound on the category range
+	DefaultCategoryRange = uint32(1024)
+
 	contextFile      = "/usr/share/containers/selinux/contexts"
 	selinuxDir       = "/etc/selinux/"
 	selinuxConfig    = selinuxDir + "config"
@@ -56,6 +59,9 @@ var (
 	ErrEmptyPath = errors.New("empty path")
 	// InvalidLabel is returned when an invalid label is specified.
 	InvalidLabel = errors.New("Invalid Label")
+
+	// CategoryRange allows the upper bound on the category range to be adjusted
+	CategoryRange = DefaultCategoryRange
 
 	assignRegex = regexp.MustCompile(`^([^=]+)=(.*)$`)
 	roFileLabel string
@@ -790,7 +796,7 @@ func ContainerLabels() (processLabel string, fileLabel string) {
 func addMcs(processLabel, fileLabel string) (string, string) {
 	scon, _ := NewContext(processLabel)
 	if scon["level"] != "" {
-		mcs := uniqMcs(1024)
+		mcs := uniqMcs(CategoryRange)
 		scon["level"] = mcs
 		processLabel = scon.Get()
 		scon, _ = NewContext(fileLabel)

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -13,6 +13,8 @@ const (
 	Permissive = 0
 	// Disabled constant to indicate SELinux is disabled
 	Disabled = -1
+	// DefaultCategoryRange is the upper bound on the category range
+	DefaultCategoryRange = uint32(1024)
 )
 
 var (
@@ -20,6 +22,8 @@ var (
 	ErrMCSAlreadyExists = errors.New("MCS label already exists")
 	// ErrEmptyPath is returned when an empty path has been specified.
 	ErrEmptyPath = errors.New("empty path")
+	// CategoryRange allows the upper bound on the category range to be adjusted
+	CategoryRange = DefaultCategoryRange
 )
 
 // Context is a representation of the SELinux label broken into 4 parts


### PR DESCRIPTION
This keeps the range as part of the global state of the package but allows users
to modify the upper bounds of the category range.

Signed-off-by: Michael Crosby <michael@thepasture.io>