### PR TITLE
mountLabel can be changed without changing processLabel

### DIFF
--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -73,9 +73,9 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 				selinux.ReleaseLabel(processLabel)
 			}
 			processLabel = pcon.Get()
-			mountLabel = mcon.Get()
 			selinux.ReserveLabel(processLabel)
 		}
+		mountLabel = mcon.Get()
 	}
 	return processLabel, mountLabel, nil
 }


### PR DESCRIPTION
If user specifies

podman run -ti --security-opt label=filetype:usr_t ...

We are ignoring the filetype change, iff the process content is not changed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>