### PR TITLE
selinux: separate API from implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ endif
 
 .PHONY: test
 test: check-gopath
-	bash -c "diff  <(grep '^func [A-Z]' go-selinux/selinux_stub.go) <(grep '^func [A-Z]' go-selinux/selinux_linux.go)"
 	go test -timeout 3m -tags "${BUILDTAGS}" ${TESTFLAGS} -v ./...
 	go test -timeout 3m ${TESTFLAGS} -v ./...
 

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -1,0 +1,249 @@
+package selinux
+
+import (
+	"github.com/pkg/errors"
+)
+
+const (
+	// Enforcing constant indicate SELinux is in enforcing mode
+	Enforcing = 1
+	// Permissive constant to indicate SELinux is in permissive mode
+	Permissive = 0
+	// Disabled constant to indicate SELinux is disabled
+	Disabled = -1
+
+	// DefaultCategoryRange is the upper bound on the category range
+	DefaultCategoryRange = uint32(1024)
+)
+
+var (
+	// ErrMCSAlreadyExists is returned when trying to allocate a duplicate MCS.
+	ErrMCSAlreadyExists = errors.New("MCS label already exists")
+	// ErrEmptyPath is returned when an empty path has been specified.
+	ErrEmptyPath = errors.New("empty path")
+
+	// InvalidLabel is returned when an invalid label is specified.
+	InvalidLabel = errors.New("Invalid Label")
+
+	// ErrIncomparable is returned two levels are not comparable
+	ErrIncomparable = errors.New("incomparable levels")
+	// ErrLevelSyntax is returned when a sensitivity or category do not have correct syntax in a level
+	ErrLevelSyntax = errors.New("invalid level syntax")
+
+	// CategoryRange allows the upper bound on the category range to be adjusted
+	CategoryRange = DefaultCategoryRange
+)
+
+// Context is a representation of the SELinux label broken into 4 parts
+type Context map[string]string
+
+// SetDisabled disables SELinux support for the package
+func SetDisabled() {
+	setDisabled()
+}
+
+// GetEnabled returns whether SELinux is currently enabled.
+func GetEnabled() bool {
+	return getEnabled()
+}
+
+// ClassIndex returns the int index for an object class in the loaded policy,
+// or -1 and an error
+func ClassIndex(class string) (int, error) {
+	return classIndex(class)
+}
+
+// SetFileLabel sets the SELinux label for this path or returns an error.
+func SetFileLabel(fpath string, label string) error {
+	return setFileLabel(fpath, label)
+}
+
+// FileLabel returns the SELinux label for this path or returns an error.
+func FileLabel(fpath string) (string, error) {
+	return fileLabel(fpath)
+}
+
+// SetFSCreateLabel tells kernel the label to create all file system objects
+// created by this task. Setting label="" to return to default.
+func SetFSCreateLabel(label string) error {
+	return setFSCreateLabel(label)
+}
+
+// FSCreateLabel returns the default label the kernel which the kernel is using
+// for file system objects created by this task. "" indicates default.
+func FSCreateLabel() (string, error) {
+	return fsCreateLabel()
+}
+
+// CurrentLabel returns the SELinux label of the current process thread, or an error.
+func CurrentLabel() (string, error) {
+	return currentLabel()
+}
+
+// PidLabel returns the SELinux label of the given pid, or an error.
+func PidLabel(pid int) (string, error) {
+	return pidLabel(pid)
+}
+
+// ExecLabel returns the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error.
+func ExecLabel() (string, error) {
+	return execLabel()
+}
+
+// CanonicalizeContext takes a context string and writes it to the kernel
+// the function then returns the context that the kernel will use. Use this
+// function to check if two contexts are equivalent
+func CanonicalizeContext(val string) (string, error) {
+	return canonicalizeContext(val)
+}
+
+// ComputeCreateContext requests the type transition from source to target for
+// class from the kernel.
+func ComputeCreateContext(source string, target string, class string) (string, error) {
+	return computeCreateContext(source, target, class)
+}
+
+// CalculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
+// of a source and target range.
+// The glblub is calculated as the greater of the low sensitivities and
+// the lower of the high sensitivities and the and of each category bitset.
+func CalculateGlbLub(sourceRange, targetRange string) (string, error) {
+	return calculateGlbLub(sourceRange, targetRange)
+}
+
+// SetExecLabel sets the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error.
+func SetExecLabel(label string) error {
+	return setExecLabel(label)
+}
+
+// SetTaskLabel sets the SELinux label for the current thread, or an error.
+// This requires the dyntransition permission.
+func SetTaskLabel(label string) error {
+	return setTaskLabel(label)
+}
+
+// SetSocketLabel takes a process label and tells the kernel to assign the
+// label to the next socket that gets created
+func SetSocketLabel(label string) error {
+	return setSocketLabel(label)
+}
+
+// SocketLabel retrieves the current socket label setting
+func SocketLabel() (string, error) {
+	return socketLabel()
+}
+
+// PeerLabel retrieves the label of the client on the other side of a socket
+func PeerLabel(fd uintptr) (string, error) {
+	return peerLabel(fd)
+}
+
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(label string) error {
+	return setKeyLabel(label)
+}
+
+// KeyLabel retrieves the current kernel keyring label setting
+func KeyLabel() (string, error) {
+	return keyLabel()
+}
+
+// Get returns the Context as a string
+func (c Context) Get() string {
+	return c.get()
+}
+
+// NewContext creates a new Context struct from the specified label
+func NewContext(label string) (Context, error) {
+	return newContext(label)
+}
+
+// ClearLabels clears all reserved labels
+func ClearLabels() {
+	clearLabels()
+}
+
+// ReserveLabel reserves the MLS/MCS level component of the specified label
+func ReserveLabel(label string) {
+	reserveLabel(label)
+}
+
+// EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+func EnforceMode() int {
+	return enforceMode()
+}
+
+// SetEnforceMode sets the current SELinux mode Enforcing, Permissive.
+// Disabled is not valid, since this needs to be set at boot time.
+func SetEnforceMode(mode int) error {
+	return setEnforceMode(mode)
+}
+
+// DefaultEnforceMode returns the systems default SELinux mode Enforcing,
+// Permissive or Disabled. Note this is is just the default at boot time.
+// EnforceMode tells you the systems current mode.
+func DefaultEnforceMode() int {
+	return defaultEnforceMode()
+}
+
+// ReleaseLabel un-reserves the MLS/MCS Level field of the specified label,
+// allowing it to be used by another process.
+func ReleaseLabel(label string) {
+	releaseLabel(label)
+}
+
+// ROFileLabel returns the specified SELinux readonly file label
+func ROFileLabel() string {
+	return roFileLabel()
+}
+
+// KVMContainerLabels returns the default processLabel and mountLabel to be used
+// for kvm containers by the calling process.
+func KVMContainerLabels() (string, string) {
+	return kvmContainerLabels()
+}
+
+// InitContainerLabels returns the default processLabel and file labels to be
+// used for containers running an init system like systemd by the calling process.
+func InitContainerLabels() (string, string) {
+	return initContainerLabels()
+}
+
+// ContainerLabels returns an allocated processLabel and fileLabel to be used for
+// container labeling by the calling process.
+func ContainerLabels() (processLabel string, fileLabel string) {
+	return containerLabels()
+}
+
+// SecurityCheckContext validates that the SELinux label is understood by the kernel
+func SecurityCheckContext(val string) error {
+	return securityCheckContext(val)
+}
+
+// CopyLevel returns a label with the MLS/MCS level from src label replaced on
+// the dest label.
+func CopyLevel(src, dest string) (string, error) {
+	return copyLevel(src, dest)
+}
+
+// Chcon changes the fpath file object to the SELinux label label.
+// If fpath is a directory and recurse is true, then Chcon walks the
+// directory tree setting the label.
+func Chcon(fpath string, label string, recurse bool) error {
+	return chcon(fpath, label, recurse)
+}
+
+// DupSecOpt takes an SELinux process label and returns security options that
+// can be used to set the SELinux Type and Level for future container processes.
+func DupSecOpt(src string) ([]string, error) {
+	return dupSecOpt(src)
+}
+
+// DisableSecOpt returns a security opt that can be used to disable SELinux
+// labeling support for future container processes.
+func DisableSecOpt() []string {
+	return disableSecOpt()
+}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	minSensLen = 2
-
+	minSensLen       = 2
 	contextFile      = "/usr/share/containers/selinux/contexts"
 	selinuxDir       = "/etc/selinux/"
 	selinuxConfig    = selinuxDir + "config"

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -100,7 +100,7 @@ func (s *selinuxState) getEnabled() bool {
 	return s.setEnable(enabled)
 }
 
-// setDisabled disables selinux support for the package
+// setDisabled disables SELinux support for the package
 func setDisabled() {
 	state.setEnable(false)
 }
@@ -193,14 +193,14 @@ func (s *selinuxState) getSELinuxfs() string {
 
 // getSelinuxMountPoint returns the path to the mountpoint of an selinuxfs
 // filesystem or an empty string if no mountpoint is found.  Selinuxfs is
-// a proc-like pseudo-filesystem that exposes the selinux policy API to
+// a proc-like pseudo-filesystem that exposes the SELinux policy API to
 // processes.  The existence of an selinuxfs mount is used to determine
-// whether selinux is currently enabled or not.
+// whether SELinux is currently enabled or not.
 func getSelinuxMountPoint() string {
 	return state.getSELinuxfs()
 }
 
-// getEnabled returns whether selinux is currently enabled.
+// getEnabled returns whether SELinux is currently enabled.
 func getEnabled() bool {
 	return state.getEnabled()
 }
@@ -285,7 +285,8 @@ func readCon(fpath string) (string, error) {
 	return strings.Trim(retval, "\x00"), nil
 }
 
-// classIndex returns the int index for an object class in the loaded policy, or -1 and an error
+// classIndex returns the int index for an object class in the loaded policy,
+// or -1 and an error
 func classIndex(class string) (int, error) {
 	permpath := fmt.Sprintf("class/%s/index", class)
 	indexpath := filepath.Join(getSelinuxMountPoint(), permpath)
@@ -330,18 +331,14 @@ func fileLabel(fpath string) (string, error) {
 	return string(label), nil
 }
 
-/*
-setFSCreateLabel tells kernel the label to create all file system objects
-created by this task. Setting label="" to return to default.
-*/
+// setFSCreateLabel tells kernel the label to create all file system objects
+// created by this task. Setting label="" to return to default.
 func setFSCreateLabel(label string) error {
 	return writeAttr("fscreate", label)
 }
 
-/*
-fsCreateLabel returns the default label the kernel which the kernel is using
-for file system objects created by this task. "" indicates default.
-*/
+// fsCreateLabel returns the default label the kernel which the kernel is using
+// for file system objects created by this task. "" indicates default.
 func fsCreateLabel() (string, error) {
 	return readAttr("fscreate")
 }
@@ -356,10 +353,8 @@ func pidLabel(pid int) (string, error) {
 	return readCon(fmt.Sprintf("/proc/%d/attr/current", pid))
 }
 
-/*
-ExecLabel returns the SELinux label that the kernel will use for any programs
-that are executed by the current process thread, or an error.
-*/
+// ExecLabel returns the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error.
 func execLabel() (string, error) {
 	return readAttr("exec")
 }
@@ -421,18 +416,15 @@ func writeAttr(attr, val string) error {
 	return writeCon(attrPath(attr), val)
 }
 
-/*
-canonicalizeContext takes a context string and writes it to the kernel
-the function then returns the context that the kernel will use.  This function
-can be used to see if two contexts are equivalent
-*/
+// canonicalizeContext takes a context string and writes it to the kernel
+// the function then returns the context that the kernel will use. Use this
+// function to check if two contexts are equivalent
 func canonicalizeContext(val string) (string, error) {
 	return readWriteCon(filepath.Join(getSelinuxMountPoint(), "context"), val)
 }
 
-/*
-computeCreateContext requests the type transition from source to target for class  from the kernel.
-*/
+// computeCreateContext requests the type transition from source to target for
+// class from the kernel.
 func computeCreateContext(source string, target string, class string) (string, error) {
 	classidx, err := classIndex(class)
 	if err != nil {
@@ -675,18 +667,14 @@ func readWriteCon(fpath string, val string) (string, error) {
 	return strings.Trim(retval, "\x00"), nil
 }
 
-/*
-setExecLabel sets the SELinux label that the kernel will use for any programs
-that are executed by the current process thread, or an error.
-*/
+// setExecLabel sets the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error.
 func setExecLabel(label string) error {
 	return writeAttr("exec", label)
 }
 
-/*
-setTaskLabel sets the SELinux label for the current thread, or an error.
-This requires the dyntransition permission.
-*/
+// setTaskLabel sets the SELinux label for the current thread, or an error.
+// This requires the dyntransition permission.
 func setTaskLabel(label string) error {
 	return writeAttr("current", label)
 }
@@ -788,19 +776,15 @@ func enforceMode() int {
 	return enforce
 }
 
-/*
-setEnforceMode sets the current SELinux mode Enforcing, Permissive.
-Disabled is not valid, since this needs to be set at boot time.
-*/
+// setEnforceMode sets the current SELinux mode Enforcing, Permissive.
+// Disabled is not valid, since this needs to be set at boot time.
 func setEnforceMode(mode int) error {
 	return ioutil.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0644)
 }
 
-/*
-defaultEnforceMode returns the systems default SELinux mode Enforcing,
-Permissive or Disabled. Note this is is just the default at boot time.
-EnforceMode tells you the systems current mode.
-*/
+// defaultEnforceMode returns the systems default SELinux mode Enforcing,
+// Permissive or Disabled. Note this is is just the default at boot time.
+// EnforceMode tells you the systems current mode.
 func defaultEnforceMode() int {
 	switch readConfig(selinuxTag) {
 	case "enforcing":
@@ -881,10 +865,8 @@ func uniqMcs(catRange uint32) string {
 	return mcs
 }
 
-/*
-releaseLabel will unreserve the MLS/MCS Level field of the specified label.
-Allowing it to be used by another process.
-*/
+// releaseLabel un-reserves the MLS/MCS Level field of the specified label,
+// allowing it to be used by another process.
 func releaseLabel(label string) {
 	if len(label) != 0 {
 		con := strings.SplitN(label, ":", 4)
@@ -951,10 +933,8 @@ func loadLabels() map[string]string {
 	return labels
 }
 
-/*
-kvmContainerLabels returns the default processLabel and mountLabel to be used
-for kvm containers by the calling process.
-*/
+// kvmContainerLabels returns the default processLabel and mountLabel to be used
+// for kvm containers by the calling process.
 func kvmContainerLabels() (string, string) {
 	processLabel := labels["kvm_process"]
 	if processLabel == "" {
@@ -964,10 +944,8 @@ func kvmContainerLabels() (string, string) {
 	return addMcs(processLabel, labels["file"])
 }
 
-/*
-initContainerLabels returns the default processLabel and file labels to be
-used for containers running an init system like systemd by the calling process.
-*/
+// initContainerLabels returns the default processLabel and file labels to be
+// used for containers running an init system like systemd by the calling process.
 func initContainerLabels() (string, string) {
 	processLabel := labels["init_process"]
 	if processLabel == "" {
@@ -977,10 +955,8 @@ func initContainerLabels() (string, string) {
 	return addMcs(processLabel, labels["file"])
 }
 
-/*
-containerLabels returns an allocated processLabel and fileLabel to be used for
-container labeling by the calling process.
-*/
+// containerLabels returns an allocated processLabel and fileLabel to be used for
+// container labeling by the calling process.
 func containerLabels() (processLabel string, fileLabel string) {
 	if !getEnabled() {
 		return "", ""
@@ -1019,10 +995,8 @@ func securityCheckContext(val string) error {
 	return ioutil.WriteFile(path.Join(getSelinuxMountPoint(), "context"), []byte(val), 0644)
 }
 
-/*
-copyLevel returns a label with the MLS/MCS level from src label replaced on
-the dest label.
-*/
+// copyLevel returns a label with the MLS/MCS level from src label replaced on
+// the dest label.
 func copyLevel(src, dest string) (string, error) {
 	if src == "" {
 		return "", nil
@@ -1047,7 +1021,7 @@ func copyLevel(src, dest string) (string, error) {
 	return tcon.Get(), nil
 }
 
-// Prevent users from relabing system files
+// Prevent users from relabeling system files
 func badPrefix(fpath string) error {
 	if fpath == "" {
 		return ErrEmptyPath
@@ -1063,7 +1037,7 @@ func badPrefix(fpath string) error {
 }
 
 // chcon changes the fpath file object to the SELinux label label.
-// If fpath is a directory and recurse is true, Chcon will walk the
+// If fpath is a directory and recurse is true, then chcon walks the
 // directory tree setting the label.
 func chcon(fpath string, label string, recurse bool) error {
 	if fpath == "" {

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -2,261 +2,234 @@
 
 package selinux
 
-import (
-	"errors"
-)
-
-const (
-	// Enforcing constant indicate SELinux is in enforcing mode
-	Enforcing = 1
-	// Permissive constant to indicate SELinux is in permissive mode
-	Permissive = 0
-	// Disabled constant to indicate SELinux is disabled
-	Disabled = -1
-	// DefaultCategoryRange is the upper bound on the category range
-	DefaultCategoryRange = uint32(1024)
-)
-
-var (
-	// ErrMCSAlreadyExists is returned when trying to allocate a duplicate MCS.
-	ErrMCSAlreadyExists = errors.New("MCS label already exists")
-	// ErrEmptyPath is returned when an empty path has been specified.
-	ErrEmptyPath = errors.New("empty path")
-	// CategoryRange allows the upper bound on the category range to be adjusted
-	CategoryRange = DefaultCategoryRange
-)
-
-// Context is a representation of the SELinux label broken into 4 parts
-type Context map[string]string
-
-// SetDisabled disables selinux support for the package
-func SetDisabled() {
+// setDisabled disables selinux support for the package
+func setDisabled() {
 }
 
-// GetEnabled returns whether selinux is currently enabled.
-func GetEnabled() bool {
+// getEnabled returns whether selinux is currently enabled.
+func getEnabled() bool {
 	return false
 }
 
-// ClassIndex returns the int index for an object class in the loaded policy, or -1 and an error
-func ClassIndex(class string) (int, error) {
+// classIndex returns the int index for an object class in the loaded policy, or -1 and an error
+func classIndex(class string) (int, error) {
 	return -1, nil
 }
 
 // SetFileLabel sets the SELinux label for this path or returns an error.
-func SetFileLabel(fpath string, label string) error {
+func setFileLabel(fpath string, label string) error {
 	return nil
 }
 
-// FileLabel returns the SELinux label for this path or returns an error.
-func FileLabel(fpath string) (string, error) {
+// fileLabel returns the SELinux label for this path or returns an error.
+func fileLabel(fpath string) (string, error) {
 	return "", nil
 }
 
 /*
-SetFSCreateLabel tells kernel the label to create all file system objects
+setFSCreateLabel tells kernel the label to create all file system objects
 created by this task. Setting label="" to return to default.
 */
-func SetFSCreateLabel(label string) error {
+func setFSCreateLabel(label string) error {
 	return nil
 }
 
 /*
-FSCreateLabel returns the default label the kernel which the kernel is using
+fsCreateLabel returns the default label the kernel which the kernel is using
 for file system objects created by this task. "" indicates default.
 */
-func FSCreateLabel() (string, error) {
+func fsCreateLabel() (string, error) {
 	return "", nil
 }
 
-// CurrentLabel returns the SELinux label of the current process thread, or an error.
-func CurrentLabel() (string, error) {
+// currentLabel returns the SELinux label of the current process thread, or an error.
+func currentLabel() (string, error) {
 	return "", nil
 }
 
 // PidLabel returns the SELinux label of the given pid, or an error.
-func PidLabel(pid int) (string, error) {
+func pidLabel(pid int) (string, error) {
 	return "", nil
 }
 
 /*
-ExecLabel returns the SELinux label that the kernel will use for any programs
+execLabel returns the SELinux label that the kernel will use for any programs
 that are executed by the current process thread, or an error.
 */
-func ExecLabel() (string, error) {
+func execLabel() (string, error) {
 	return "", nil
 }
 
 /*
-CanonicalizeContext takes a context string and writes it to the kernel
+canonicalizeContext takes a context string and writes it to the kernel
 the function then returns the context that the kernel will use.  This function
 can be used to see if two contexts are equivalent
 */
-func CanonicalizeContext(val string) (string, error) {
+func canonicalizeContext(val string) (string, error) {
 	return "", nil
 }
 
 /*
-ComputeCreateContext requests the type transition from source to target for class  from the kernel.
+computeCreateContext requests the type transition from source to target for class  from the kernel.
 */
-func ComputeCreateContext(source string, target string, class string) (string, error) {
+func computeCreateContext(source string, target string, class string) (string, error) {
 	return "", nil
 }
 
-// CalculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
+// calculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
 // of a source and target range.
 // The glblub is calculated as the greater of the low sensitivities and
 // the lower of the high sensitivities and the and of each category bitmap.
-func CalculateGlbLub(sourceRange, targetRange string) (string, error) {
+func calculateGlbLub(sourceRange, targetRange string) (string, error) {
 	return "", nil
 }
 
 /*
-SetExecLabel sets the SELinux label that the kernel will use for any programs
+setExecLabel sets the SELinux label that the kernel will use for any programs
 that are executed by the current process thread, or an error.
 */
-func SetExecLabel(label string) error {
+func setExecLabel(label string) error {
 	return nil
 }
 
 /*
-SetTaskLabel sets the SELinux label for the current thread, or an error.
+setTaskLabel sets the SELinux label for the current thread, or an error.
 This requires the dyntransition permission.
 */
-func SetTaskLabel(label string) error {
+func setTaskLabel(label string) error {
 	return nil
 }
 
 /*
-SetSocketLabel sets the SELinux label that the kernel will use for any programs
+setSocketLabel sets the SELinux label that the kernel will use for any programs
 that are executed by the current process thread, or an error.
 */
-func SetSocketLabel(label string) error {
+func setSocketLabel(label string) error {
 	return nil
 }
 
-// SocketLabel retrieves the current socket label setting
-func SocketLabel() (string, error) {
+// socketLabel retrieves the current socket label setting
+func socketLabel() (string, error) {
 	return "", nil
 }
 
-// PeerLabel retrieves the label of the client on the other side of a socket
-func PeerLabel(fd uintptr) (string, error) {
+// peerLabel retrieves the label of the client on the other side of a socket
+func peerLabel(fd uintptr) (string, error) {
 	return "", nil
 }
 
-// SetKeyLabel takes a process label and tells the kernel to assign the
+// setKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
-func SetKeyLabel(label string) error {
+func setKeyLabel(label string) error {
 	return nil
 }
 
-// KeyLabel retrieves the current kernel keyring label setting
-func KeyLabel() (string, error) {
+// keyLabel retrieves the current kernel keyring label setting
+func keyLabel() (string, error) {
 	return "", nil
 }
 
 // Get returns the Context as a string
-func (c Context) Get() string {
+func (c Context) get() string {
 	return ""
 }
 
-// NewContext creates a new Context struct from the specified label
-func NewContext(label string) (Context, error) {
+// newContext creates a new Context struct from the specified label
+func newContext(label string) (Context, error) {
 	c := make(Context)
 	return c, nil
 }
 
-// ClearLabels clears all reserved MLS/MCS levels
-func ClearLabels() {
+// clearLabels clears all reserved MLS/MCS levels
+func clearLabels() {
 }
 
-// ReserveLabel reserves the MLS/MCS level component of the specified label
-func ReserveLabel(label string) {
+// reserveLabel reserves the MLS/MCS level component of the specified label
+func reserveLabel(label string) {
 }
 
-// EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
-func EnforceMode() int {
+// enforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+func enforceMode() int {
 	return Disabled
 }
 
 /*
-SetEnforceMode sets the current SELinux mode Enforcing, Permissive.
+setEnforceMode sets the current SELinux mode Enforcing, Permissive.
 Disabled is not valid, since this needs to be set at boot time.
 */
-func SetEnforceMode(mode int) error {
+func setEnforceMode(mode int) error {
 	return nil
 }
 
 /*
-DefaultEnforceMode returns the systems default SELinux mode Enforcing,
+defaultEnforceMode returns the systems default SELinux mode Enforcing,
 Permissive or Disabled. Note this is is just the default at boot time.
 EnforceMode tells you the systems current mode.
 */
-func DefaultEnforceMode() int {
+func defaultEnforceMode() int {
 	return Disabled
 }
 
 /*
-ReleaseLabel will unreserve the MLS/MCS Level field of the specified label.
+releaseLabel will unreserve the MLS/MCS Level field of the specified label.
 Allowing it to be used by another process.
 */
-func ReleaseLabel(label string) {
+func releaseLabel(label string) {
 }
 
-// ROFileLabel returns the specified SELinux readonly file label
-func ROFileLabel() string {
+// roFileLabel returns the specified SELinux readonly file label
+func roFileLabel() string {
 	return ""
 }
 
-// KVMContainerLabels returns the default processLabel and mountLabel to be used
+// kvmContainerLabels returns the default processLabel and mountLabel to be used
 // for kvm containers by the calling process.
-func KVMContainerLabels() (string, string) {
+func kvmContainerLabels() (string, string) {
 	return "", ""
 }
 
-// InitContainerLabels returns the default processLabel and file labels to be
+// initContainerLabels returns the default processLabel and file labels to be
 // used for containers running an init system like systemd by the calling
-func InitContainerLabels() (string, string) {
+func initContainerLabels() (string, string) {
 	return "", ""
 }
 
 /*
-ContainerLabels returns an allocated processLabel and fileLabel to be used for
+containerLabels returns an allocated processLabel and fileLabel to be used for
 container labeling by the calling process.
 */
-func ContainerLabels() (processLabel string, fileLabel string) {
+func containerLabels() (processLabel string, fileLabel string) {
 	return "", ""
 }
 
-// SecurityCheckContext validates that the SELinux label is understood by the kernel
-func SecurityCheckContext(val string) error {
+// securityCheckContext validates that the SELinux label is understood by the kernel
+func securityCheckContext(val string) error {
 	return nil
 }
 
 /*
-CopyLevel returns a label with the MLS/MCS level from src label replaced on
+copyLevel returns a label with the MLS/MCS level from src label replaced on
 the dest label.
 */
-func CopyLevel(src, dest string) (string, error) {
+func copyLevel(src, dest string) (string, error) {
 	return "", nil
 }
 
-// Chcon changes the `fpath` file object to the SELinux label `label`.
+// chcon changes the `fpath` file object to the SELinux label `label`.
 // If `fpath` is a directory and `recurse`` is true, Chcon will walk the
 // directory tree setting the label.
-func Chcon(fpath string, label string, recurse bool) error {
+func chcon(fpath string, label string, recurse bool) error {
 	return nil
 }
 
-// DupSecOpt takes an SELinux process label and returns security options that
+// dupSecOpt takes an SELinux process label and returns security options that
 // can be used to set the SELinux Type and Level for future container processes.
-func DupSecOpt(src string) ([]string, error) {
+func dupSecOpt(src string) ([]string, error) {
 	return nil, nil
 }
 
-// DisableSecOpt returns a security opt that can be used to disable SELinux
+// disableSecOpt returns a security opt that can be used to disable SELinux
 // labeling support for future container processes.
-func DisableSecOpt() []string {
+func disableSecOpt() []string {
 	return []string{"disable"}
 }

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -2,234 +2,147 @@
 
 package selinux
 
-// setDisabled disables selinux support for the package
 func setDisabled() {
 }
 
-// getEnabled returns whether selinux is currently enabled.
 func getEnabled() bool {
 	return false
 }
 
-// classIndex returns the int index for an object class in the loaded policy, or -1 and an error
 func classIndex(class string) (int, error) {
 	return -1, nil
 }
 
-// SetFileLabel sets the SELinux label for this path or returns an error.
 func setFileLabel(fpath string, label string) error {
 	return nil
 }
 
-// fileLabel returns the SELinux label for this path or returns an error.
 func fileLabel(fpath string) (string, error) {
 	return "", nil
 }
 
-/*
-setFSCreateLabel tells kernel the label to create all file system objects
-created by this task. Setting label="" to return to default.
-*/
 func setFSCreateLabel(label string) error {
 	return nil
 }
 
-/*
-fsCreateLabel returns the default label the kernel which the kernel is using
-for file system objects created by this task. "" indicates default.
-*/
 func fsCreateLabel() (string, error) {
 	return "", nil
 }
 
-// currentLabel returns the SELinux label of the current process thread, or an error.
 func currentLabel() (string, error) {
 	return "", nil
 }
 
-// PidLabel returns the SELinux label of the given pid, or an error.
 func pidLabel(pid int) (string, error) {
 	return "", nil
 }
 
-/*
-execLabel returns the SELinux label that the kernel will use for any programs
-that are executed by the current process thread, or an error.
-*/
 func execLabel() (string, error) {
 	return "", nil
 }
 
-/*
-canonicalizeContext takes a context string and writes it to the kernel
-the function then returns the context that the kernel will use.  This function
-can be used to see if two contexts are equivalent
-*/
 func canonicalizeContext(val string) (string, error) {
 	return "", nil
 }
 
-/*
-computeCreateContext requests the type transition from source to target for class  from the kernel.
-*/
 func computeCreateContext(source string, target string, class string) (string, error) {
 	return "", nil
 }
 
-// calculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
-// of a source and target range.
-// The glblub is calculated as the greater of the low sensitivities and
-// the lower of the high sensitivities and the and of each category bitmap.
 func calculateGlbLub(sourceRange, targetRange string) (string, error) {
 	return "", nil
 }
 
-/*
-setExecLabel sets the SELinux label that the kernel will use for any programs
-that are executed by the current process thread, or an error.
-*/
 func setExecLabel(label string) error {
 	return nil
 }
 
-/*
-setTaskLabel sets the SELinux label for the current thread, or an error.
-This requires the dyntransition permission.
-*/
 func setTaskLabel(label string) error {
 	return nil
 }
 
-/*
-setSocketLabel sets the SELinux label that the kernel will use for any programs
-that are executed by the current process thread, or an error.
-*/
 func setSocketLabel(label string) error {
 	return nil
 }
 
-// socketLabel retrieves the current socket label setting
 func socketLabel() (string, error) {
 	return "", nil
 }
 
-// peerLabel retrieves the label of the client on the other side of a socket
 func peerLabel(fd uintptr) (string, error) {
 	return "", nil
 }
 
-// setKeyLabel takes a process label and tells the kernel to assign the
-// label to the next kernel keyring that gets created
 func setKeyLabel(label string) error {
 	return nil
 }
 
-// keyLabel retrieves the current kernel keyring label setting
 func keyLabel() (string, error) {
 	return "", nil
 }
 
-// Get returns the Context as a string
 func (c Context) get() string {
 	return ""
 }
 
-// newContext creates a new Context struct from the specified label
 func newContext(label string) (Context, error) {
 	c := make(Context)
 	return c, nil
 }
 
-// clearLabels clears all reserved MLS/MCS levels
 func clearLabels() {
 }
 
-// reserveLabel reserves the MLS/MCS level component of the specified label
 func reserveLabel(label string) {
 }
 
-// enforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
 func enforceMode() int {
 	return Disabled
 }
 
-/*
-setEnforceMode sets the current SELinux mode Enforcing, Permissive.
-Disabled is not valid, since this needs to be set at boot time.
-*/
 func setEnforceMode(mode int) error {
 	return nil
 }
 
-/*
-defaultEnforceMode returns the systems default SELinux mode Enforcing,
-Permissive or Disabled. Note this is is just the default at boot time.
-EnforceMode tells you the systems current mode.
-*/
 func defaultEnforceMode() int {
 	return Disabled
 }
 
-/*
-releaseLabel will unreserve the MLS/MCS Level field of the specified label.
-Allowing it to be used by another process.
-*/
 func releaseLabel(label string) {
 }
 
-// roFileLabel returns the specified SELinux readonly file label
 func roFileLabel() string {
 	return ""
 }
 
-// kvmContainerLabels returns the default processLabel and mountLabel to be used
-// for kvm containers by the calling process.
 func kvmContainerLabels() (string, string) {
 	return "", ""
 }
 
-// initContainerLabels returns the default processLabel and file labels to be
-// used for containers running an init system like systemd by the calling
 func initContainerLabels() (string, string) {
 	return "", ""
 }
 
-/*
-containerLabels returns an allocated processLabel and fileLabel to be used for
-container labeling by the calling process.
-*/
 func containerLabels() (processLabel string, fileLabel string) {
 	return "", ""
 }
 
-// securityCheckContext validates that the SELinux label is understood by the kernel
 func securityCheckContext(val string) error {
 	return nil
 }
 
-/*
-copyLevel returns a label with the MLS/MCS level from src label replaced on
-the dest label.
-*/
 func copyLevel(src, dest string) (string, error) {
 	return "", nil
 }
 
-// chcon changes the `fpath` file object to the SELinux label `label`.
-// If `fpath` is a directory and `recurse`` is true, Chcon will walk the
-// directory tree setting the label.
 func chcon(fpath string, label string, recurse bool) error {
 	return nil
 }
 
-// dupSecOpt takes an SELinux process label and returns security options that
-// can be used to set the SELinux Type and Level for future container processes.
 func dupSecOpt(src string) ([]string, error) {
 	return nil, nil
 }
 
-// disableSecOpt returns a security opt that can be used to disable SELinux
-// labeling support for future container processes.
 func disableSecOpt() []string {
 	return []string{"disable"}
 }


### PR DESCRIPTION
This patch moves all exported public/API functions to a single location, and un-exports their (stubbed) implementations. With this approach, exported functions only have to be documented in a single place, and enforces signatures of stubbed and non stubbed implementations to match.
