### PR TITLE
pkg/pwalk: fix data race with err

### DIFF
--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -48,7 +48,11 @@ func WalkN(root string, walkFn WalkFunc, num int) error {
 	errCh := make(chan error, 1) // get the first error, ignore others
 
 	// Start walking a tree asap
-	var err error
+	var (
+		err error
+		wg  sync.WaitGroup
+	)
+	wg.Add(1)
 	go func() {
 		err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -68,9 +72,9 @@ func WalkN(root string, walkFn WalkFunc, num int) error {
 		if err == nil {
 			close(files)
 		}
+		wg.Done()
 	}()
 
-	var wg sync.WaitGroup
 	wg.Add(num)
 	for i := 0; i < num; i++ {
 		go func() {


### PR DESCRIPTION
Fixes: https://github.com/opencontainers/selinux/issues/108

Go race detector found a race in the code wrt err read/write:

> cd pkg/pwalk && go test -run Many -race .
> RUN   TestWalkManyErrors
> 
> WARNING: DATA RACE
> Read at 0x00c0000a0510 by goroutine 7:
>   github.com/opencontainers/selinux/pkg/pwalk.WalkN()
>       /home/kir/go/src/github.com/opencontainers/selinux/pkg/pwalk/pwalk.go:91 +0x1f8
>   github.com/opencontainers/selinux/pkg/pwalk.Walk()
>       /home/kir/go/src/github.com/opencontainers/selinux/pkg/pwalk/pwalk.go:35 +0x321
> ...
> Previous write at 0x00c0000a0510 by goroutine 8:
>   github.com/opencontainers/selinux/pkg/pwalk.WalkN.func1()
>       /home/kir/go/src/github.com/opencontainers/selinux/pkg/pwalk/pwalk.go:53 +0xa6
> ...

Indeed, we wait for all runner goroutines but do not wait for the
filetree reading goroutine (the one that calls filepath.Walk).

One way to fix it would be to not assign value to global variable err in
the filetree reading goroutine, but do that in a runner. Unfortunately,
that way we might mix up and not return the first error.

Fix by using waitgroup for the reading goroutine as well. Slightly
more complex than not assiging err in there, but guarantee we'll
return the first error.