### PR TITLE
Fix compile error on go 1.13

### DIFF
--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -395,7 +395,7 @@ func TestGlbLub(t *testing.T) {
 		if err != tt.expectedErr {
 			switch e := errors.Cause(err).(type) {
 			case *strconv.NumError:
-				if e.Unwrap() == tt.expectedErr {
+				if e.Err == tt.expectedErr {
 					continue
 				}
 			default:


### PR DESCRIPTION
`stconv.NumError.Unwrap()` was added in Go 1.14 (https://github.com/golang/go/commit/0adc89aa962aa116da5540c3248977318d360738), so compile failed on Go 1.13 and older:

    WARN [runner] Can't run linter unused: buildssa: analysis skipped: errors in package: [/home/travis/gopath/src/github.com/opencontainers/selinux/go-selinux/selinux_linux_test.go:398:10: e.Unwrap undefined (type *strconv.NumError has no field or method Unwrap)]
    WARN [runner] Can't run linter goanalysis_metalinter: interfacer: failed prerequisites: buildssa@github.com/opencontainers/selinux/go-selinux [github.com/opencontainers/selinux/go-selinux.test]

This patch changes the test to check the .Err (which is what `Unwrap()` returns.

This was introduced in https://github.com/opencontainers/selinux/pull/103, but for some reason, CI didn't run:

<img width="831" alt="Screenshot 2020-07-03 at 20 16 10" src="https://user-images.githubusercontent.com/1804568/86491111-108bc580-bd6a-11ea-83f3-bf6655fe22ac.png">

