### PR TITLE
travis: add go 1.15, rm unsupported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.12.x
-  - 1.13.x
+  - 1.14.x
+  - 1.15.x
   - tip
 
 before_install:


### PR DESCRIPTION
Since go 1.15 is out, go 1.13 is no longer supported.