### PR TITLE
Makefile: fix vendor (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ lint: ${GOLANGCI_LINT}
 
 .PHONY: vendor
 vendor:
-	GO111MODULE=on \
-		$(GO) mod tidy && \
-		$(GO) mod vendor && \
-		$(GO) mod verify
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify


### PR DESCRIPTION
The previous fix (#117) was not entirely correct, since now
`GO111MODULE` env var only applies to the first command.

In fact, `GO111MODULE` setting is no longer needed, since the global
`GO111MODULE=off` was removed by commit 4ee005d6e50e, so let's remove
it from here to avoid confusion.

Also, && is not needed either.

Surely, if someone tries something like

	GO111MODULE=off make vendor

it won't work, but I don't think it should.