### PR TITLE
Implement get_default_context_with_level() from libselinux

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -30,6 +30,11 @@ var (
 	// ErrLevelSyntax is returned when a sensitivity or category do not have correct syntax in a level
 	ErrLevelSyntax = errors.New("invalid level syntax")
 
+	// ErrContextMissing is returned if a requested context is not found in a file.
+	ErrContextMissing = errors.New("context does not have a match")
+	// ErrVerifierNil is returned when a context verifier function is nil.
+	ErrVerifierNil = errors.New("verifier function is nil")
+
 	// CategoryRange allows the upper bound on the category range to be adjusted
 	CategoryRange = DefaultCategoryRange
 )
@@ -261,4 +266,13 @@ func DupSecOpt(src string) ([]string, error) {
 // labeling support for future container processes.
 func DisableSecOpt() []string {
 	return disableSecOpt()
+}
+
+// GetDefaultContextWithLevel gets a single context for the specified SELinux user
+// identity that is reachable from the specified scon context. The context is based
+// on the per-user /etc/selinux/{SELINUXTYPE}/contexts/users/<username> if it exists,
+// and falls back to the global /etc/selinux/{SELINUXTYPE}/contexts/default_contexts
+// file.
+func GetDefaultContextWithLevel(user, level, scon string) (string, error) {
+	return getDefaultContextWithLevel(user, level, scon)
 }

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -207,28 +207,16 @@ func getEnabled() bool {
 }
 
 func readConfig(target string) string {
-	var (
-		val, key string
-		bufin    *bufio.Reader
-	)
-
 	in, err := os.Open(selinuxConfig)
 	if err != nil {
 		return ""
 	}
 	defer in.Close()
 
-	bufin = bufio.NewReader(in)
+	scanner := bufio.NewScanner(in)
 
-	for done := false; !done; {
-		var line string
-		if line, err = bufin.ReadString('\n'); err != nil {
-			if err != io.EOF {
-				return ""
-			}
-			done = true
-		}
-		line = strings.TrimSpace(line)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
 		if len(line) == 0 {
 			// Skip blank lines
 			continue
@@ -238,7 +226,7 @@ func readConfig(target string) string {
 			continue
 		}
 		if groups := assignRegex.FindStringSubmatch(line); groups != nil {
-			key, val = strings.TrimSpace(groups[1]), strings.TrimSpace(groups[2])
+			key, val := strings.TrimSpace(groups[1]), strings.TrimSpace(groups[2])
 			if key == target {
 				return strings.Trim(val, "\"")
 			}
@@ -889,11 +877,6 @@ func openContextFile() (*os.File, error) {
 var labels = loadLabels()
 
 func loadLabels() map[string]string {
-	var (
-		val, key string
-		bufin    *bufio.Reader
-	)
-
 	labels := make(map[string]string)
 	in, err := openContextFile()
 	if err != nil {
@@ -901,18 +884,10 @@ func loadLabels() map[string]string {
 	}
 	defer in.Close()
 
-	bufin = bufio.NewReader(in)
+	scanner := bufio.NewScanner(in)
 
-	for done := false; !done; {
-		var line string
-		if line, err = bufin.ReadString('\n'); err != nil {
-			if err == io.EOF {
-				done = true
-			} else {
-				break
-			}
-		}
-		line = strings.TrimSpace(line)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
 		if len(line) == 0 {
 			// Skip blank lines
 			continue
@@ -922,7 +897,7 @@ func loadLabels() map[string]string {
 			continue
 		}
 		if groups := assignRegex.FindStringSubmatch(line); groups != nil {
-			key, val = strings.TrimSpace(groups[1]), strings.TrimSpace(groups[2])
+			key, val := strings.TrimSpace(groups[1]), strings.TrimSpace(groups[2])
 			labels[key] = strings.Trim(val, "\"")
 		}
 	}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -35,6 +35,8 @@ const (
 	xattrNameSelinux = "security.selinux"
 )
 
+var policyRoot = filepath.Join(selinuxDir, readConfig(selinuxTypeTag))
+
 type selinuxState struct {
 	enabledSet    bool
 	enabled       bool
@@ -243,10 +245,6 @@ func readConfig(target string) string {
 		}
 	}
 	return ""
-}
-
-func getSELinuxPolicyRoot() string {
-	return filepath.Join(selinuxDir, readConfig(selinuxTypeTag))
 }
 
 func isProcHandle(fh *os.File) error {
@@ -884,7 +882,7 @@ func openContextFile() (*os.File, error) {
 	if f, err := os.Open(contextFile); err == nil {
 		return f, nil
 	}
-	lxcPath := filepath.Join(getSELinuxPolicyRoot(), "/contexts/lxc_contexts")
+	lxcPath := filepath.Join(policyRoot, "/contexts/lxc_contexts")
 	return os.Open(lxcPath)
 }
 

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -146,3 +146,7 @@ func dupSecOpt(src string) ([]string, error) {
 func disableSecOpt() []string {
 	return []string{"disable"}
 }
+
+func getDefaultContextWithLevel(user, level, scon string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
This PR:

- implements get_default_context_with_level() from libselinux.
- change parser code for the SELinux config and label files to use bufio.Scanner
- cache the SELinux root policy dir value