### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,27 @@ jobs:
       script: make test BUILDTAGS=""
 
     - stage: validate
+#POWERON SUPPORT 
+    - stage: build
+      script: make
+      arch: ppc64le
+    - stage: lint
+      script: make lint BUILDTAGS=""
+      arch: ppc64le
+    - stage: test
+      script: make test BUILDTAGS=""
+      arch: ppc64le
+      go:  1.14.x
+    - stage: test
+      script: make test BUILDTAGS=""
+      arch: ppc64le
+      go: 1.15.x
+    - stage: test
+      script: make test BUILDTAGS=""
+      arch: ppc64le
+      go : tip
+    - stage: validate
+      arch: ppc64le
+
       script: |
         git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

earlier rasier PR https://github.com/opencontainers/selinux/pull/120 and had a conversation as below 

@vrothberg has suggested to add directly as below and We have confirmed adding and running the jobs ,unfortunately  it does not cover all the stages for arch  ppc64le  .


arch:
  - amd64
  - ppc64le
 have closed the earlier PR since we had many commits and confusing the details   

 
 So matrix is only help to cover all the stage and used the approch ,create this PR ,Please review now
 