### PR TITLE
travis: add ppc to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,21 @@
 language: go
 go:
-  - 1.14.x
   - 1.15.x
+  - 1.14.x
   - tip
+arch:
+  - amd64
+  - ppc64le
 
-before_install:
-  - go get -u github.com/vbatts/git-validation
-
-stages:
-  - validate
-  - build
-  - lint
-  - test
+script:
+  - make lint build test
 
 jobs:
+  allow_failures:
+    - go: tip
   include:
-    - stage: build
-      script: make
-
-    - stage: lint
-      script: make lint BUILDTAGS=""
-
-    - stage: test
-      script: make test BUILDTAGS=""
-
     - stage: validate
-      script: |
-        git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
+      before_script: go get -u github.com/vbatts/git-validation
+      script: git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
+    - stage: build-cross
+      script: make build-cross


### PR DESCRIPTION
This is an alternative to #121 with a more concise travis syntax, using the matrix.

Now, git-validation and build-cross are separate things that do no make
sense to have in the matrix, so separate them out to additional jobs.
    
While at it, allow `go: tip` to fail.
    
NOTE that testing with and without selinux tag is handled by the
Makefile, so we do not add this dimension to the matrix.

Closes: #121