### PR TITLE
golangci revamp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,19 +4,3 @@ run:
     - selinux
   concurrency: 6
   deadline: 5m
-linters:
-  enable-all: true
-  disable:
-    - errcheck
-    - funlen
-    - gochecknoglobals
-    - gocognit
-    - gocritic
-    - golint
-    - gomnd
-    - ineffassign
-    - lll
-    - staticcheck
-    - stylecheck
-    - whitespace
-    - wsl

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ build-cross:
 BUILD_PATH := $(shell pwd)/build
 BUILD_BIN_PATH := ${BUILD_PATH}/bin
 GOLANGCI_LINT := ${BUILD_BIN_PATH}/golangci-lint
+GOLANGCI_INSTALL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+GOLANGCI_VERSION := v1.31.0
 
 .PHONY: check-gopath
 check-gopath:
@@ -48,11 +50,7 @@ test: check-gopath
 	go test -timeout 3m ${TESTFLAGS} -v ./...
 
 ${GOLANGCI_LINT}:
-	export \
-		VERSION=v1.23.7 \
-		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
-		BINDIR=${BUILD_BIN_PATH} && \
-	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
+	curl -sSfL ${GOLANGCI_INSTALL} | sh -s -- -b ${BUILD_BIN_PATH} ${GOLANGCI_VERSION}
 
 .PHONY: lint
 lint: ${GOLANGCI_LINT}

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -16,7 +16,7 @@ func TestInit(t *testing.T) {
 		return
 	}
 	var testNull []string
-	plabel, mlabel, err := InitLabels(testNull)
+	_, _, err := InitLabels(testNull)
 	if err != nil {
 		t.Log("InitLabels Failed")
 		t.Fatal(err)
@@ -26,7 +26,7 @@ func TestInit(t *testing.T) {
 	if roMountLabel == "" {
 		t.Errorf("ROMountLabel Failed")
 	}
-	plabel, mlabel, err = InitLabels(testDisabled)
+	plabel, _, err := InitLabels(testDisabled)
 	if err != nil {
 		t.Log("InitLabels Disabled Failed")
 		t.Fatal(err)
@@ -36,7 +36,7 @@ func TestInit(t *testing.T) {
 		t.FailNow()
 	}
 	testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
-	plabel, mlabel, err = InitLabels(testUser)
+	plabel, mlabel, err := InitLabels(testUser)
 	if err != nil {
 		t.Log("InitLabels User Failed")
 		t.Fatal(err)

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -751,7 +751,7 @@ func reserveLabel(label string) {
 	if len(label) != 0 {
 		con := strings.SplitN(label, ":", 4)
 		if len(con) > 3 {
-			mcsAdd(con[3])
+			_ = mcsAdd(con[3])
 		}
 	}
 }
@@ -844,9 +844,9 @@ func uniqMcs(catRange uint32) string {
 	)
 
 	for {
-		binary.Read(rand.Reader, binary.LittleEndian, &n)
+		_ = binary.Read(rand.Reader, binary.LittleEndian, &n)
 		c1 = n % catRange
-		binary.Read(rand.Reader, binary.LittleEndian, &n)
+		_ = binary.Read(rand.Reader, binary.LittleEndian, &n)
 		c2 = n % catRange
 		if c1 == c2 {
 			continue
@@ -1015,7 +1015,7 @@ func copyLevel(src, dest string) (string, error) {
 		return "", err
 	}
 	mcsDelete(tcon["level"])
-	mcsAdd(scon["level"])
+	_ = mcsAdd(scon["level"])
 	tcon["level"] = scon["level"]
 	return tcon.Get(), nil
 }

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -140,7 +140,9 @@ func TestSetEnforceMode(t *testing.T) {
 	t.Log("Enforcing Mode:", EnforceMode())
 	mode := DefaultEnforceMode()
 	t.Log("Default Enforce Mode:", mode)
-	defer SetEnforceMode(mode)
+	defer func() {
+		_ = SetEnforceMode(mode)
+	}()
 
 	if err := SetEnforceMode(Enforcing); err != nil {
 		t.Fatalf("setting selinux mode to enforcing failed: %v", err)
@@ -425,6 +427,8 @@ func BenchmarkChcon(b *testing.B) {
 	b.Logf("Chcon(%q, %q)", dir, con)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		Chcon(dir, con, true)
+		if err := Chcon(dir, con, true); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -261,7 +261,7 @@ func TestClassIndex(t *testing.T) {
 		t.Errorf("ClassIndex unexpected answer %d, possibly not reference policy", idx)
 	}
 
-	idx, err = ClassIndex("foobar")
+	_, err = ClassIndex("foobar")
 	if err == nil {
 		t.Errorf("ClassIndex(\"foobar\") succeeded, expected to fail:")
 	}
@@ -289,7 +289,7 @@ func TestComputeCreateContext(t *testing.T) {
 	process := "process"
 	// Test to ensure that a bad context returns an error
 	t.Logf("ComputeCreateContext(%s, %s, %s)", badcon, tmp, process)
-	context, err = ComputeCreateContext(badcon, tmp, process)
+	_, err = ComputeCreateContext(badcon, tmp, process)
 	if err == nil {
 		t.Errorf("ComputeCreateContext(%s, %s, %s) succeeded, expected failure", badcon, tmp, process)
 	}


### PR DESCRIPTION
1. Bump golangci-lint.
2. Simplify its install.
3. Fix some ineffassign and errcheck warnings.
4. Use the default set of linters.