### PR TITLE
pkg/pwalk: improve docs

### DIFF
--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -20,17 +20,16 @@ type WalkFunc = filepath.WalkFunc
 //
 // Note that this implementation only supports primitive error handling:
 //
-// * no errors are ever passed to WalkFn
+// - no errors are ever passed to WalkFn;
 //
-// * once a walkFn returns any error, all further processing stops
-//   and the error is returned to the caller of Walk;
+// - once a walkFn returns any error, all further processing stops
+// and the error is returned to the caller of Walk;
 //
-// * filepath.SkipDir is not supported;
+// - filepath.SkipDir is not supported;
 //
-// * if more than one walkFn instance will return an error, only one
-//   of such errors will be propagated and returned by Walk, others
-//   will be silently discarded.
-//
+// - if more than one walkFn instance will return an error, only one
+// of such errors will be propagated and returned by Walk, others
+// will be silently discarded.
 func Walk(root string, walkFn WalkFunc) error {
 	return WalkN(root, walkFn, runtime.NumCPU()*2)
 }
@@ -38,6 +37,8 @@ func Walk(root string, walkFn WalkFunc) error {
 // WalkN is a wrapper for filepath.Walk which can call multiple walkFn
 // in parallel, allowing to handle each item concurrently. A maximum of
 // num walkFn will be called at any one time.
+//
+// Please see Walk documentation for caveats of using this function.
 func WalkN(root string, walkFn WalkFunc, num int) error {
 	// make sure limit is sensible
 	if num < 1 {


### PR DESCRIPTION
1. Improve docs formatting (lines with spaces at BOL are rendered
   as HTML pre/code, see [1]).

2. Add note to WalkN to see Walk doc for caveats.

[1] https://pkg.go.dev/github.com/opencontainers/selinux@v1.6.0/pkg/pwalk
