### PR TITLE
lint: fix warnings from whitespace and gocritic, enable those

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,3 +4,6 @@ run:
     - selinux
   concurrency: 6
   deadline: 5m
+linters:
+  enable:
+    - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ run:
 linters:
   enable:
     - whitespace
+    - gocritic

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -27,14 +27,14 @@ var ErrIncompatibleLabel = errors.New("Bad SELinux option z and Z can not be use
 // the container.  A list of options can be passed into this function to alter
 // the labels.  The labels returned will include a random MCS String, that is
 // guaranteed to be unique.
-func InitLabels(options []string) (plabel string, mlabel string, Err error) {
+func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 	if !selinux.GetEnabled() {
 		return "", "", nil
 	}
 	processLabel, mountLabel := selinux.ContainerLabels()
 	if processLabel != "" {
 		defer func() {
-			if Err != nil {
+			if retErr != nil {
 				selinux.ReleaseLabel(mountLabel)
 			}
 		}()

--- a/go-selinux/label/label_selinux.go
+++ b/go-selinux/label/label_selinux.go
@@ -57,7 +57,6 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 			con := strings.SplitN(opt, ":", 2)
 			if !validOptions[con[0]] {
 				return "", "", errors.Errorf("Bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
-
 			}
 			if con[0] == "filetype" {
 				mcon["type"] = con[1]

--- a/go-selinux/label/label_selinux_test.go
+++ b/go-selinux/label/label_selinux_test.go
@@ -157,7 +157,6 @@ func TestIsShared(t *testing.T) {
 	if shared := IsShared("Zz"); !shared {
 		t.Fatalf("Expected label `Zz` to be shared, got %v", shared)
 	}
-
 }
 
 func TestSELinuxNoLevel(t *testing.T) {

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -828,11 +828,11 @@ func intToMcs(id int, catRange uint32) string {
 	}
 
 	for ORD > TIER {
-		ORD = ORD - TIER
+		ORD -= TIER
 		TIER--
 	}
 	TIER = SETSIZE - TIER
-	ORD = ORD + TIER
+	ORD += TIER
 	return fmt.Sprintf("s0:c%d,c%d", TIER, ORD)
 }
 
@@ -850,10 +850,8 @@ func uniqMcs(catRange uint32) string {
 		c2 = n % catRange
 		if c1 == c2 {
 			continue
-		} else {
-			if c1 > c2 {
-				c1, c2 = c2, c1
-			}
+		} else if c1 > c2 {
+			c1, c2 = c2, c1
 		}
 		mcs = fmt.Sprintf("s0:c%d,c%d", c1, c2)
 		if err := mcsAdd(mcs); err != nil {

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -48,7 +48,6 @@ func TestKVMLabels(t *testing.T) {
 	plabel, flabel := KVMContainerLabels()
 	if plabel == "" {
 		t.Log("Failed to read kvm label")
-
 	}
 	t.Log(plabel)
 	t.Log(flabel)
@@ -267,8 +266,8 @@ func TestClassIndex(t *testing.T) {
 	if err == nil {
 		t.Errorf("ClassIndex(\"foobar\") succeeded, expected to fail:")
 	}
-
 }
+
 func TestComputeCreateContext(t *testing.T) {
 	if !GetEnabled() {
 		t.Skip("SELinux not enabled, skipping.")
@@ -295,7 +294,6 @@ func TestComputeCreateContext(t *testing.T) {
 	if err == nil {
 		t.Errorf("ComputeCreateContext(%s, %s, %s) succeeded, expected failure", badcon, tmp, process)
 	}
-
 }
 
 func TestGlbLub(t *testing.T) {


### PR DESCRIPTION
#### 1. Vertical whitespace nits.
    
Found by whitespace linter:
    
    go-selinux/label/label_selinux.go:60: unnecessary trailing newline (whitespace)
    
    go-selinux/label/label_selinux_test.go:160: unnecessary trailing newline (whitespace)

    go-selinux/selinux_linux_test.go:51: unnecessary trailing newline (whitespace)
    
Fix these, enable the linter.

#### 2.  Fix gocritic warnings, enable the linter
   
The warnings were:
    
    go-selinux/label/label_selinux.go:30:66: captLocal: `Err' should not be capitalized (gocritic)
    func InitLabels(options []string) (plabel string, mlabel string, Err error) {
                                                                     ^
    go-selinux/selinux_linux.go:831:3: assignOp: replace `ORD = ORD - TIER` with `ORD -= TIER` (gocritic)
                    ORD = ORD - TIER
                    ^
    go-selinux/selinux_linux.go:835:2: assignOp: replace `ORD = ORD + TIER` with `ORD += TIER` (gocritic)
            ORD = ORD + TIER
            ^
    go-selinux/selinux_linux.go:853:10: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
                    } else {
                           ^