### PR TITLE
go-selinux: retry on EINTR

### DIFF
--- a/go-selinux/xattrs.go
+++ b/go-selinux/xattrs.go
@@ -6,25 +6,35 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Returns a []byte slice if the xattr is set and nil otherwise
-// Requires path and its attribute as arguments
-func lgetxattr(path string, attr string) ([]byte, error) {
+// lgetxattr returns a []byte slice containing the value of
+// an extended attribute attr set for path.
+func lgetxattr(path, attr string) ([]byte, error) {
 	// Start with a 128 length byte array
 	dest := make([]byte, 128)
-	sz, errno := unix.Lgetxattr(path, attr, dest)
+	sz, errno := doLgetxattr(path, attr, dest)
 	for errno == unix.ERANGE {
 		// Buffer too small, use zero-sized buffer to get the actual size
-		sz, errno = unix.Lgetxattr(path, attr, []byte{})
+		sz, errno = doLgetxattr(path, attr, []byte{})
 		if errno != nil {
 			return nil, errno
 		}
 
 		dest = make([]byte, sz)
-		sz, errno = unix.Lgetxattr(path, attr, dest)
+		sz, errno = doLgetxattr(path, attr, dest)
 	}
 	if errno != nil {
 		return nil, errno
 	}
 
 	return dest[:sz], nil
+}
+
+// doLgetxattr is a wrapper that retries on EINTR
+func doLgetxattr(path, attr string, dest []byte) (int, error) {
+	for {
+		sz, err := unix.Lgetxattr(path, attr, dest)
+		if err != unix.EINTR {
+			return sz, err
+		}
+	}
 }


### PR DESCRIPTION
Wrap some syscalls (lgetattr, lsetattr, fstatfs, statfs)
to retry on EINTR, just in case.

Related:
 - https://github.com/containers/storage/pull/757
 - https://go-review.googlesource.com/c/go/+/249178
 - https://github.com/golang/go/issues/38033