### PR TITLE
readme: update security URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Participation in the OpenContainers community is governed by [OpenContainer's Co
 
 If you find an issue, please follow the [security][security] protocol to report it.
 
-[security]: https://github.com/opencontainers/org/blob/master/security
+[security]: https://github.com/opencontainers/org/blob/master/SECURITY.md
 [code-of-conduct]: https://github.com/opencontainers/org/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
URL was broken -- update to the new .md

Fixes: #128

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>