### PR TITLE
Remove "selinux" build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,8 @@
 GO ?= go
-BUILDTAGS := selinux
 
 all: build build-cross
 
 define go-build
-	GOOS=$(1) GOARCH=$(2) $(GO) build -tags $(BUILDTAGS) ./...
-endef
-
-define go-build-noselinux
 	GOOS=$(1) GOARCH=$(2) $(GO) build ./...
 endef
 
@@ -24,13 +19,6 @@ build-cross:
 	$(call go-build,linux,s390x)
 	$(call go-build,windows,amd64)
 	$(call go-build,windows,386)
-	$(call go-build-noselinux,linux,amd64)
-	$(call go-build-noselinux,linux,arm)
-	$(call go-build-noselinux,linux,arm64)
-	$(call go-build-noselinux,linux,ppc64le)
-	$(call go-build-noselinux,linux,s390x)
-	$(call go-build-noselinux,windows,amd64)
-	$(call go-build-noselinux,windows,386)
 
 BUILD_PATH := $(shell pwd)/build
 BUILD_BIN_PATH := ${BUILD_PATH}/bin
@@ -46,7 +34,6 @@ endif
 
 .PHONY: test
 test: check-gopath
-	go test -timeout 3m -tags "${BUILDTAGS}" ${TESTFLAGS} -v ./...
 	go test -timeout 3m ${TESTFLAGS} -v ./...
 
 ${GOLANGCI_LINT}:
@@ -56,7 +43,6 @@ ${GOLANGCI_LINT}:
 lint: ${GOLANGCI_LINT}
 	${GOLANGCI_LINT} version
 	${GOLANGCI_LINT} linters
-	${GOLANGCI_LINT} run --build-tags "${BUILDTAGS}"
 	${GOLANGCI_LINT} run
 
 .PHONY: vendor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Common SELinux package used across the container ecosystem.
 
 ## Usage
 
-When compiling consumers of this project, the `selinux` build tag must be used to enable selinux functionality.
+Prior to v1.8.0, the `selinux` build tag had to be used to enable selinux functionality for compiling consumers of this project.
+Starting with v1.8.0, the `selinux` build tag is no longer needed.
 
 For complete documentation, see [godoc](https://godoc.org/github.com/opencontainers/selinux).
 

--- a/go-selinux/doc.go
+++ b/go-selinux/doc.go
@@ -5,9 +5,6 @@ This package uses a selinux build tag to enable the selinux functionality. This
 allows non-linux and linux users who do not have selinux support to still use
 tools that rely on this library.
 
-To compile with full selinux support use the -tags=selinux option in your build
-and test commands.
-
 Usage:
 
 	import "github.com/opencontainers/selinux/go-selinux"

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -1,5 +1,3 @@
-// +build selinux,linux
-
 package label
 
 import (

--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -1,5 +1,3 @@
-// +build selinux,linux
-
 package label
 
 import (

--- a/go-selinux/label/label_stub.go
+++ b/go-selinux/label/label_stub.go
@@ -1,4 +1,4 @@
-// +build !selinux !linux
+// +build !linux
 
 package label
 

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -1,4 +1,4 @@
-// +build !selinux !linux
+// +build !linux
 
 package label
 

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -1,5 +1,3 @@
-// +build selinux,linux
-
 package selinux
 
 import (

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -1,5 +1,3 @@
-// +build selinux,linux
-
 package selinux
 
 import (

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -1,4 +1,4 @@
-// +build !selinux !linux
+// +build !linux
 
 package selinux
 

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -1,4 +1,4 @@
-// +build !selinux !linux
+// +build !linux
 
 package selinux
 
@@ -8,7 +8,7 @@ import (
 
 func TestSELinux(t *testing.T) {
 	if GetEnabled() {
-		t.Fatal("SELinux enabled with build-tag !selinux.")
+		t.Fatal("SELinux enabled on non-linux.")
 	}
 
 	if _, err := FileLabel("/etc"); err != nil {

--- a/go-selinux/xattrs_linux.go
+++ b/go-selinux/xattrs_linux.go
@@ -1,5 +1,3 @@
-// +build selinux,linux
-
 package selinux
 
 import (


### PR DESCRIPTION
This project is matured enough and does not have any cgo dependency, so "selinux" build tag can be removed safely.

Close #130
