### PR TITLE
doc.go: remove outdated description about the build tag

### DIFF
--- a/go-selinux/doc.go
+++ b/go-selinux/doc.go
@@ -1,10 +1,6 @@
 /*
 Package selinux provides a high-level interface for interacting with selinux.
 
-This package uses a selinux build tag to enable the selinux functionality. This
-allows non-linux and linux users who do not have selinux support to still use
-tools that rely on this library.
-
 Usage:
 
 	import "github.com/opencontainers/selinux/go-selinux"


### PR DESCRIPTION
Follow-up to #132

Sorry I missed this