### PR TITLE
filePath: fix deadlock

### DIFF
--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -55,6 +55,7 @@ func WalkN(root string, walkFn WalkFunc, num int) error {
 	)
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
 			if err != nil {
 				close(files)
@@ -73,7 +74,6 @@ func WalkN(root string, walkFn WalkFunc, num int) error {
 		if err == nil {
 			close(files)
 		}
-		wg.Done()
 	}()
 
 	wg.Add(num)


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

A goroutine returning before calling waitGroup.Done() can cause a deadlock.
Fix this by using defer waitGroup.Done() at the top.

Example: https://play.golang.com/p/n3w0T0wg-6c