### PR TITLE
support mips64le architecture.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 arch:
   - amd64
   - ppc64le
+  - mips64le
 
 script:
   - make lint build test

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build-cross:
 	$(call go-build,linux,arm64)
 	$(call go-build,linux,ppc64le)
 	$(call go-build,linux,s390x)
+	$(call go-build,linux,mips64le)
 	$(call go-build,windows,amd64)
 	$(call go-build,windows,386)
 


### PR DESCRIPTION
I am going to submit mips64le architecture，The main reasons are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported;
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.
Signed-off-by: houfangdong houfangdong@loongson.com