### PR TITLE
Free SELinux labels when the labels are not being used

### DIFF
--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -47,7 +47,8 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 		}
 		for _, opt := range options {
 			if opt == "disable" {
-				return "", mountLabel, nil
+				selinux.ReleaseLabel(processLabel)
+				return "", "", nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
 				return "", "", errors.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)


### PR DESCRIPTION
This is a cherry-pick of the following from projectatomic/docker altered
for this version of opencontainers/selinux.

https://github.com/projectatomic/docker/pull/381

Currently when lots of containers are created as disabled, each
container will leak and MCS Label.  Eventually the system will run out
of labels and go into an infinate loop looking for labels.

This also fixes a problem that caused relabeling to occur even when
label=disable was specified, such as with privileged containers.

Signed-off-by: Robb Manes <rmanes@redhat.com>