### PR TITLE
Reserve one Category for the privileged containers to use

### DIFF
--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -29,15 +29,19 @@ func TestInit(t *testing.T) {
 	if roMountLabel == "" {
 		t.Fatal("ROMountLabel: empty")
 	}
-	plabel, _, err := InitLabels(testDisabled)
+	plabel, mlabel, err := InitLabels(testDisabled)
 	if err != nil {
 		t.Fatalf("InitLabels(disabled) failed: %v", err)
 	}
 	if plabel != "" {
 		t.Fatalf("InitLabels(disabled): %q not empty", plabel)
 	}
+	if mlabel != "system_u:object_r:container_file_t:s0:c1022,c1023" {
+		t.Fatalf("InitLabels Disabled mlabel Failed, %s", mlabel)
+	}
+
 	testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
-	plabel, mlabel, err := InitLabels(testUser)
+	plabel, mlabel, err = InitLabels(testUser)
 	if err != nil {
 		t.Fatalf("InitLabels(user) failed: %v", err)
 	}
@@ -172,7 +176,7 @@ func TestSELinuxNoLevel(t *testing.T) {
 		t.Fatal(err)
 	}
 	if con.Get() != tlabel {
-		t.Errorf("NewContaxt and con.Get() failed on non mls label: expexcted %q, got %q", tlabel, con.Get())
+		t.Errorf("NewContaxt and con.Get() failed on non mls label: expected %q, got %q", tlabel, con.Get())
 	}
 }
 

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -22,14 +22,16 @@ func TestInit(t *testing.T) {
 	if roMountLabel != "" {
 		t.Errorf("ROMountLabel Failed")
 	}
-	plabel, _, err := InitLabels(testDisabled)
+	plabel, mlabel, err := InitLabels(testDisabled)
 	if err != nil {
 		t.Log("InitLabels Disabled Failed")
 		t.Fatal(err)
 	}
 	if plabel != "" {
-		t.Log("InitLabels Disabled Failed")
-		t.FailNow()
+		t.Fatal("InitLabels Disabled Failed")
+	}
+	if mlabel != "" {
+		t.Fatal("InitLabels Disabled mlabel Failed")
 	}
 	testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
 	_, _, err = InitLabels(testUser)

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -11,9 +11,10 @@ const (
 	Permissive = 0
 	// Disabled constant to indicate SELinux is disabled
 	Disabled = -1
-
+	// maxCategory is the maximum number of categories used within containers
+	maxCategory = 1024
 	// DefaultCategoryRange is the upper bound on the category range
-	DefaultCategoryRange = uint32(1024)
+	DefaultCategoryRange = uint32(maxCategory)
 )
 
 var (
@@ -275,4 +276,9 @@ func DisableSecOpt() []string {
 // file.
 func GetDefaultContextWithLevel(user, level, scon string) (string, error) {
 	return getDefaultContextWithLevel(user, level, scon)
+}
+
+// PrivContainerMountLabel returns mount label for privileged containers
+func PrivContainerMountLabel() string {
+	return privContainerMountLabel
 }

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -892,13 +892,13 @@ func openContextFile() (*os.File, error) {
 	return os.Open(lxcPath)
 }
 
-var labels = loadLabels()
+var labels, privContainerMountLabel = loadLabels()
 
-func loadLabels() map[string]string {
+func loadLabels() (map[string]string, string) {
 	labels := make(map[string]string)
 	in, err := openContextFile()
 	if err != nil {
-		return labels
+		return labels, ""
 	}
 	defer in.Close()
 
@@ -920,7 +920,10 @@ func loadLabels() map[string]string {
 		}
 	}
 
-	return labels
+	con, _ := NewContext(labels["file"])
+	con["level"] = fmt.Sprintf("s0:c%d,c%d", maxCategory-2, maxCategory-1)
+	reserveLabel(con.get())
+	return labels, con.get()
 }
 
 // kvmContainerLabels returns the default processLabel and mountLabel to be used

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -2,6 +2,8 @@
 
 package selinux
 
+const privContainerMountLabel = ""
+
 func setDisabled() {
 }
 


### PR DESCRIPTION
Currently each privileged container is reserving a different category
to make sure that other containers can not see their content. This
wastes container categories.  This PR will reserve one category for
all privileged containers (s0:c1023,c1024), and free all of the
other categories for confined containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>