### PR TITLE
Add pwalkdir, speed up chcon

### DIFF
--- a/go-selinux/rchcon.go
+++ b/go-selinux/rchcon.go
@@ -1,0 +1,22 @@
+// +build linux,go1.16
+
+package selinux
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/opencontainers/selinux/pkg/pwalkdir"
+)
+
+func rchcon(fpath, label string) error {
+	return pwalkdir.Walk(fpath, func(p string, _ fs.DirEntry, _ error) error {
+		e := setFileLabel(p, label)
+		// Walk a file tree can race with removal, so ignore ENOENT.
+		if errors.Is(e, os.ErrNotExist) {
+			return nil
+		}
+		return e
+	})
+}

--- a/go-selinux/rchcon_go115.go
+++ b/go-selinux/rchcon_go115.go
@@ -1,0 +1,21 @@
+// +build linux,!go1.16
+
+package selinux
+
+import (
+	"errors"
+	"os"
+
+	"github.com/opencontainers/selinux/pkg/pwalk"
+)
+
+func rchcon(fpath, label string) error {
+	return pwalk.Walk(fpath, func(p string, _ os.FileInfo, _ error) error {
+		e := setFileLabel(p, label)
+		// Walk a file tree can race with removal, so ignore ENOENT.
+		if errors.Is(e, os.ErrNotExist) {
+			return nil
+		}
+		return e
+	})
+}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 
 	"github.com/bits-and-blooms/bitset"
-	"github.com/opencontainers/selinux/pkg/pwalk"
 	"golang.org/x/sys/unix"
 )
 
@@ -1048,17 +1047,10 @@ func chcon(fpath string, label string, recurse bool) error {
 	}
 
 	if !recurse {
-		return SetFileLabel(fpath, label)
+		return setFileLabel(fpath, label)
 	}
 
-	return pwalk.Walk(fpath, func(p string, info os.FileInfo, err error) error {
-		e := SetFileLabel(p, label)
-		// Walk a file tree can race with removal, so ignore ENOENT
-		if errors.Is(e, os.ErrNotExist) {
-			return nil
-		}
-		return e
-	})
+	return rchcon(fpath, label)
 }
 
 // dupSecOpt takes an SELinux process label and returns security options that

--- a/pkg/pwalk/README.md
+++ b/pkg/pwalk/README.md
@@ -8,6 +8,12 @@ By default, it utilizes 2\*runtime.NumCPU() goroutines for callbacks.
 This can be changed by using WalkN function which has the additional
 parameter, specifying the number of goroutines (concurrency).
 
+### pwalk vs pwalkdir
+
+This package is deprecated in favor of
+[pwalkdir](https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalkdir),
+which is faster, but requires at least Go 1.16.
+
 ### Caveats
 
 Please note the following limitations of this code:

--- a/pkg/pwalkdir/README.md
+++ b/pkg/pwalkdir/README.md
@@ -1,0 +1,54 @@
+## pwalkdir: parallel implementation of filepath.WalkDir
+
+This is a wrapper for [filepath.WalkDir](https://pkg.go.dev/path/filepath#WalkDir)
+which may speed it up by calling multiple callback functions (WalkDirFunc)
+in parallel, utilizing goroutines.
+
+By default, it utilizes 2\*runtime.NumCPU() goroutines for callbacks.
+This can be changed by using WalkN function which has the additional
+parameter, specifying the number of goroutines (concurrency).
+
+### pwalk vs pwalkdir
+
+This package is very similar to
+[pwalk](https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalkdir),
+but utilizes `filepath.WalkDir` (added to Go 1.16), which does not call stat(2)
+on every entry and is therefore faster (up to 3x, depending on usage scenario).
+
+Users who are OK with requiring Go 1.16+ should switch to this
+implementation.
+
+### Caveats
+
+Please note the following limitations of this code:
+
+* Unlike filepath.WalkDir, the order of calls is non-deterministic;
+
+* Only primitive error handling is supported:
+
+  * fs.SkipDir is not supported;
+
+  * no errors are ever passed to WalkDirFunc;
+
+  * once any error is returned from any walkDirFunc instance, no more calls
+    to WalkDirFunc are made, and the error is returned to the caller of WalkDir;
+
+  * if more than one WalkDirFunc instance will return an error, only one
+    of such errors will be propagated to and returned by WalkDir, others
+    will be silently discarded.
+
+### Documentation
+
+For the official documentation, see
+https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalkdir
+
+### Benchmarks
+
+For a WalkDirFunc that consists solely of the return statement, this
+implementation is about 15% slower than the standard library's
+filepath.WalkDir.
+
+Otherwise (if a WalkDirFunc is actually doing something) this is usually
+faster, except when the WalkDirN(..., 1) is used. Run `go test -bench .`
+to see how different operations can benefit from it, as well as how the
+level of paralellism affects the speed.

--- a/pkg/pwalkdir/pwalkdir.go
+++ b/pkg/pwalkdir/pwalkdir.go
@@ -1,0 +1,103 @@
+// +build go1.16
+
+package pwalkdir
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// Walk is a wrapper for filepath.WalkDir which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// twice the runtime.NumCPU() walkFn will be called at any one time.
+// If you want to change the maximum, use WalkN instead.
+//
+// The order of calls is non-deterministic.
+//
+// Note that this implementation only supports primitive error handling:
+//
+// - no errors are ever passed to walkFn;
+//
+// - once a walkFn returns any error, all further processing stops
+// and the error is returned to the caller of Walk;
+//
+// - filepath.SkipDir is not supported;
+//
+// - if more than one walkFn instance will return an error, only one
+// of such errors will be propagated and returned by Walk, others
+// will be silently discarded.
+func Walk(root string, walkFn fs.WalkDirFunc) error {
+	return WalkN(root, walkFn, runtime.NumCPU()*2)
+}
+
+// WalkN is a wrapper for filepath.WalkDir which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// num walkFn will be called at any one time.
+//
+// Please see Walk documentation for caveats of using this function.
+func WalkN(root string, walkFn fs.WalkDirFunc, num int) error {
+	// make sure limit is sensible
+	if num < 1 {
+		return fmt.Errorf("walk(%q): num must be > 0", root)
+	}
+
+	files := make(chan *walkArgs, 2*num)
+	errCh := make(chan error, 1) // Get the first error, ignore others.
+
+	// Start walking a tree asap.
+	var (
+		err error
+		wg  sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		err = filepath.WalkDir(root, func(p string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				close(files)
+				return err
+			}
+			// Add a file to the queue unless a callback sent an error.
+			select {
+			case e := <-errCh:
+				close(files)
+				return e
+			default:
+				files <- &walkArgs{path: p, entry: entry}
+				return nil
+			}
+		})
+		if err == nil {
+			close(files)
+		}
+		wg.Done()
+	}()
+
+	wg.Add(num)
+	for i := 0; i < num; i++ {
+		go func() {
+			for file := range files {
+				if e := walkFn(file.path, file.entry, nil); e != nil {
+					select {
+					case errCh <- e: // sent ok
+					default: // buffer full
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	return err
+}
+
+// walkArgs holds the arguments that were passed to the Walk or WalkN
+// functions.
+type walkArgs struct {
+	path  string
+	entry fs.DirEntry
+}

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -1,0 +1,222 @@
+// +build go1.16
+
+package pwalkdir
+
+import (
+	"errors"
+	"io/fs"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWalkDir(t *testing.T) {
+	var count uint32
+	concurrency := runtime.NumCPU() * 2
+
+	dir, total, err := prepareTestSet(3, 2, 1)
+	if err != nil {
+		t.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	err = WalkN(dir,
+		func(_ string, _ fs.DirEntry, _ error) error {
+			atomic.AddUint32(&count, 1)
+			return nil
+		},
+		concurrency)
+
+	if err != nil {
+		t.Errorf("Walk failed: %v", err)
+	}
+	if count != uint32(total) {
+		t.Errorf("File count mismatch: found %d, expected %d", count, total)
+	}
+
+	t.Logf("concurrency: %d, files found: %d\n", concurrency, count)
+}
+
+func TestWalkDirManyErrors(t *testing.T) {
+	var count uint32
+
+	dir, total, err := prepareTestSet(3, 3, 2)
+	if err != nil {
+		t.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	max := uint32(total / 2)
+	e42 := errors.New("42")
+	err = Walk(dir,
+		func(p string, e fs.DirEntry, _ error) error {
+			if atomic.AddUint32(&count, 1) > max {
+				return e42
+			}
+			return nil
+		})
+	t.Logf("found %d of %d files", count, total)
+
+	if err == nil {
+		t.Error("Walk succeeded, but error is expected")
+		if count != uint32(total) {
+			t.Errorf("File count mismatch: found %d, expected %d", count, total)
+		}
+	}
+}
+
+func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error) {
+	for d := 0; d < dirs; d++ {
+		var dir string
+		dir, err = ioutil.TempDir(prefix, "d-")
+		if err != nil {
+			return
+		}
+		count++
+		for f := 0; f < files; f++ {
+			fi, err := ioutil.TempFile(dir, "f-")
+			if err != nil {
+				return count, err
+			}
+			fi.Close()
+			count++
+		}
+		if levels == 0 {
+			continue
+		}
+		var c int
+		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
+			return
+		}
+		count += c
+	}
+
+	return
+}
+
+// prepareTestSet() creates a directory tree of shallow files,
+// to be used for testing or benchmarking.
+//
+// Total dirs: dirs^levels + dirs^(levels-1) + ... + dirs^1
+// Total files: total_dirs * files
+func prepareTestSet(levels, dirs, files int) (dir string, total int, err error) {
+	dir, err = ioutil.TempDir(".", "pwalk-test-")
+	if err != nil {
+		return
+	}
+	total, err = makeManyDirs(dir, levels, dirs, files)
+	if err != nil && total > 0 {
+		_ = os.RemoveAll(dir)
+		dir = ""
+		total = 0
+		return
+	}
+	total++ // this dir
+
+	return
+}
+
+type walkerFunc func(root string, walkFn fs.WalkDirFunc) error
+
+func genWalkN(n int) walkerFunc {
+	return func(root string, walkFn fs.WalkDirFunc) error {
+		return WalkN(root, walkFn, n)
+	}
+}
+
+func BenchmarkWalk(b *testing.B) {
+	const (
+		levels = 5 // how deep
+		dirs   = 3 // dirs on each levels
+		files  = 8 // files on each levels
+	)
+
+	benchmarks := []struct {
+		name string
+		walk fs.WalkDirFunc
+	}{
+		{"Empty", cbEmpty},
+		{"ReadFile", cbReadFile},
+		{"ChownChmod", cbChownChmod},
+		{"RandomSleep", cbRandomSleep},
+	}
+
+	walkers := []struct {
+		name   string
+		walker walkerFunc
+	}{
+		{"filepath.WalkDir", filepath.WalkDir},
+		{"pwalkdir.Walk", Walk},
+		// test WalkN with various values of N
+		{"pwalkdir.Walk1", genWalkN(1)},
+		{"pwalkdir.Walk2", genWalkN(2)},
+		{"pwalkdir.Walk4", genWalkN(4)},
+		{"pwalkdir.Walk8", genWalkN(8)},
+		{"pwalkdir.Walk16", genWalkN(16)},
+		{"pwalkdir.Walk32", genWalkN(32)},
+		{"pwalkdir.Walk64", genWalkN(64)},
+		{"pwalkdir.Walk128", genWalkN(128)},
+		{"pwalkdir.Walk256", genWalkN(256)},
+	}
+
+	dir, total, err := prepareTestSet(levels, dirs, files)
+	if err != nil {
+		b.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	b.Logf("dataset: %d levels x %d dirs x %d files, total entries: %d", levels, dirs, files, total)
+
+	for _, bm := range benchmarks {
+		for _, w := range walkers {
+			walker := w.walker
+			walkFn := bm.walk
+			// preheat
+			err := w.walker(dir, bm.walk)
+			if err != nil {
+				b.Errorf("walk failed: %v", err)
+			}
+			// benchmark
+			b.Run(bm.name+"/"+w.name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					err := walker(dir, walkFn)
+					if err != nil {
+						b.Errorf("walk failed: %v", err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func cbEmpty(_ string, _ fs.DirEntry, _ error) error {
+	return nil
+}
+
+func cbChownChmod(path string, e fs.DirEntry, _ error) error {
+	_ = os.Chown(path, 0, 0)
+	mode := os.FileMode(0o644)
+	if e.IsDir() {
+		mode = os.FileMode(0o755)
+	}
+	_ = os.Chmod(path, mode)
+
+	return nil
+}
+
+func cbReadFile(path string, e fs.DirEntry, _ error) error {
+	var err error
+	if e.Type().IsRegular() {
+		_, err = ioutil.ReadFile(path)
+	}
+	return err
+}
+
+func cbRandomSleep(_ string, _ fs.DirEntry, _ error) error {
+	time.Sleep(time.Duration(rand.Intn(500)) * time.Microsecond)
+	return nil
+}


### PR DESCRIPTION
TL;DR: speed up chcon for up to 1.5x to 2x with Go 1.16+.

1. pkg/pwalkdir: add
    
    This is a copy-paste implementation of pwalk but utilizing
    filepath.WalkDir instead (added in Go 1.16). As WalkDir do not call
    stat(2) on every entry, it is much (2x on my machine) faster than Walk
    (see below).
    
    The idea is to have pwalk and pwalkdir coexist for some time, then
    gradually retire pwalk once Go < 1.16 is unsupported.

2. Chcon: speedup for Go 1.16+
    
    Using the newly added pwalkdir, the benchmark added by and described
    in commit ba956cafe09661021bf shows a considerable speed improvement
    (0.8s with pwalk, 0.5s with pwalkdir, 0.9s with chcon from GNU coreutils).
