### PR TITLE
Lazy init

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -38,6 +38,8 @@ var (
 
 	// CategoryRange allows the upper bound on the category range to be adjusted
 	CategoryRange = DefaultCategoryRange
+
+	privContainerMountLabel string
 )
 
 // Context is a representation of the SELinux label broken into 4 parts
@@ -280,5 +282,7 @@ func GetDefaultContextWithLevel(user, level, scon string) (string, error) {
 
 // PrivContainerMountLabel returns mount label for privileged containers
 func PrivContainerMountLabel() string {
+	// Make sure label is initialized.
+	_ = label("")
 	return privContainerMountLabel
 }

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -42,8 +42,6 @@ func TestKVMLabels(t *testing.T) {
 		t.Skip("SELinux not enabled, skipping.")
 	}
 
-	t.Log(labels)
-
 	plabel, flabel := KVMContainerLabels()
 	if plabel == "" {
 		t.Log("Failed to read kvm label")

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -533,3 +533,17 @@ func BenchmarkCurrentLabel(b *testing.B) {
 	}
 	b.Log(l)
 }
+
+func BenchmarkReadConfig(b *testing.B) {
+	str := ""
+	for n := 0; n < b.N; n++ {
+		str = readConfig(selinuxTypeTag)
+	}
+	b.Log(str)
+}
+
+func BenchmarkLoadLabels(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		loadLabels()
+	}
+}

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -2,8 +2,6 @@
 
 package selinux
 
-const privContainerMountLabel = ""
-
 func setDisabled() {
 }
 
@@ -151,4 +149,8 @@ func disableSecOpt() []string {
 
 func getDefaultContextWithLevel(user, level, scon string) (string, error) {
 	return "", nil
+}
+
+func label(_ string) string {
+	return ""
 }


### PR DESCRIPTION
With the following proggy:
```go
package main

import 	_ "github.com/opencontainers/selinux/go-selinux"

func main() {}
```

we can easily measure the overhead of merely importing (not actually using) the package:

```console
$ GODEBUG=inittrace=1 go run a.go 2>&1 | grep go-selinux
# github.com/opencontainers/selinux/go-selinux
init github.com/opencontainers/selinux/go-selinux @0.87 ms, 0.15 ms clock, 18328 bytes, 152 allocs
```

This PR tries to minimize that by:
* removing regex usage;
* initializing some stuff in a lazy (on demand) manner, rather than during initialization time

With these patches, we have
```console
init github.com/opencontainers/selinux/go-selinux @0.53 ms, 0 ms clock, 160 bytes, 8 allocs
```

which eliminates most of the overhead.

Besides, modified `readConfig` and `loadLabels` show some performance and memory improvements as well:
```console
[kir@kir-rhat go-selinux]$ benchstat before after
name          old time/op    new time/op    delta
ReadConfig-4    4.86µs ± 1%    3.46µs ± 2%  -28.82%  (p=0.002 n=6+6)
LoadLabels-4    12.7µs ± 3%     6.8µs ± 1%  -46.24%  (p=0.002 n=6+6)

name          old alloc/op   new alloc/op   delta
ReadConfig-4    5.08kB ± 0%    4.35kB ± 0%  -14.33%  (p=0.002 n=6+6)
LoadLabels-4    6.49kB ± 0%    6.10kB ± 0%   -6.07%  (p=0.000 n=6+5)

name          old allocs/op  new allocs/op  delta
ReadConfig-4      20.0 ± 0%       8.0 ± 0%  -60.00%  (p=0.002 n=6+6)
LoadLabels-4      45.0 ± 0%      45.0 ± 0%     ~     (all equal)
```

See individual commit messages for details.
