### PR TITLE
(Context).get: speedup

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -723,10 +723,10 @@ func keyLabel() (string, error) {
 
 // get returns the Context as a string
 func (c Context) get() string {
-	if c["level"] != "" {
-		return fmt.Sprintf("%s:%s:%s:%s", c["user"], c["role"], c["type"], c["level"])
+	if level := c["level"]; level != "" {
+		return c["user"] + ":" + c["role"] + ":" + c["type"] + ":" + level
 	}
-	return fmt.Sprintf("%s:%s:%s", c["user"], c["role"], c["type"])
+	return c["user"] + ":" + c["role"] + ":" + c["type"]
 }
 
 // newContext creates a new Context struct from the specified label

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -80,6 +80,18 @@ func TestInitLabels(t *testing.T) {
 	ReleaseLabel(plabel)
 }
 
+func BenchmarkContextGet(b *testing.B) {
+	ctx, err := NewContext("system_u:object_r:container_file_t:s0:c1022,c1023")
+	if err != nil {
+		b.Fatal(err)
+	}
+	str := ""
+	for i := 0; i < b.N; i++ {
+		str = ctx.get()
+	}
+	b.Log(str)
+}
+
 func TestSELinux(t *testing.T) {
 	if !GetEnabled() {
 		t.Skip("SELinux not enabled, skipping.")


### PR DESCRIPTION
`fmt.Sprintf` is slow. Let's use string concatenation instead, and avoid
looking up level label twice.

Benchmark shows 3x improvement in performance, and less allocations.
```
name          old time/op    new time/op    delta
ContextGet-4     277ns ± 1%      93ns ± 1%  -66.55%  (p=0.016 n=4+5)

name          old alloc/op   new alloc/op   delta
ContextGet-4      128B ± 0%       64B ± 0%     ~     (p=0.079 n=4+5)

name          old allocs/op  new allocs/op  delta
ContextGet-4      5.00 ± 0%      1.00 ± 0%     ~     (p=0.079 n=4+5)
```
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>