### PR TITLE
writeCon: no need to wrap os.Write error

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -389,7 +389,7 @@ func writeCon(fpath, val string) error {
 		_, err = out.Write(nil)
 	}
 	if err != nil {
-		return &os.PathError{Op: "write", Path: fpath, Err: err}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
The errors returned from os are usually descriptive enough
(i.e. they contain the file name and the failed operation).
    
Fixes: bb3d708b
