### PR TITLE
Add the list of container read only file types

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -38,6 +38,22 @@ var (
 
 	// CategoryRange allows the upper bound on the category range to be adjusted
 	CategoryRange = DefaultCategoryRange
+
+	ROContainerFileTypes = []string{
+		"bin_t",
+		"boot_t",
+		"etc_runtime_t",
+		"etc_t",
+		"lib_t",
+		"shell_exec_t",
+		"src_t",
+		"system_conf_t",
+		"system_db_t",
+		"textrel_shlib_t",
+		"usr_t",
+		"container_file_t",
+		"container_ro_file_t",
+	}
 )
 
 // Context is a representation of the SELinux label broken into 4 parts


### PR DESCRIPTION
These are the types of files that container domains are allowed to read.
We want this for contianer storage, to allow us to do some deduplicating
of SELinux types for use within container/storage.

This list is very static and has been basically the same for years.
Generating this programatically, while possible is very costly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>