### PR TITLE
go-selinux: add a Maybe option for Relabel and Chcon

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -256,7 +256,15 @@ func CopyLevel(src, dest string) (string, error) {
 // If fpath is a directory and recurse is true, then Chcon walks the
 // directory tree setting the label.
 func Chcon(fpath string, label string, recurse bool) error {
-	return chcon(fpath, label, recurse)
+	return chcon(fpath, label, recurse, false)
+}
+
+// MaybeChcon changes the fpath file object to the SELinux label label.
+// If fpath is a directory and recurse is true, then Chcon walks the
+// directory tree setting the label, as long as fpath was not already labeled.
+// with the requested label.
+func MaybeChcon(fpath string, label string, recurse bool) error {
+	return chcon(fpath, label, recurse, true)
 }
 
 // DupSecOpt takes an SELinux process label and returns security options that

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -135,7 +135,7 @@ func copyLevel(src, dest string) (string, error) {
 	return "", nil
 }
 
-func chcon(fpath string, label string, recurse bool) error {
+func chcon(fpath string, label string, recurse, stopIfAlreadyLabeled bool) error {
 	return nil
 }
 


### PR DESCRIPTION
When Maybe{Relabel,Chcon} are called, the path they're called for
is only relabeled when the top-level is not already labelled.

Signed-off-by: Peter Hunt <pehunt@redhat.com>