### PR TITLE
Chcon,Relabel: process the argument last

### DIFF
--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -103,9 +103,11 @@ func SetFileCreateLabel(fileLabel string) error {
 	return selinux.SetFSCreateLabel(fileLabel)
 }
 
-// Relabel changes the label of path to the filelabel string.
+// Relabel changes the label of path and all the entries beneath the path.
 // It changes the MCS label to s0 if shared is true.
 // This will allow all containers to share the content.
+//
+// The path itself is guaranteed to be relabeled last.
 func Relabel(path string, fileLabel string, shared bool) error {
 	if !selinux.GetEnabled() || fileLabel == "" {
 		return nil

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -255,6 +255,8 @@ func CopyLevel(src, dest string) (string, error) {
 // Chcon changes the fpath file object to the SELinux label label.
 // If fpath is a directory and recurse is true, then Chcon walks the
 // directory tree setting the label.
+//
+// The fpath itself is guaranteed to be relabeled last.
 func Chcon(fpath string, label string, recurse bool) error {
 	return chcon(fpath, label, recurse)
 }

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -22,8 +22,10 @@ func TestWalk(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	var last string
 	err = WalkN(dir,
-		func(_ string, _ os.FileInfo, _ error) error {
+		func(p string, _ os.FileInfo, _ error) error {
+			last = p
 			atomic.AddUint32(&count, 1)
 			return nil
 		},
@@ -34,6 +36,9 @@ func TestWalk(t *testing.T) {
 	}
 	if count != uint32(total) {
 		t.Errorf("File count mismatch: found %d, expected %d", count, total)
+	}
+	if last != dir {
+		t.Errorf("Last entry: want %q, got %q", dir, last)
 	}
 
 	t.Logf("concurrency: %d, files found: %d\n", concurrency, count)

--- a/pkg/pwalkdir/pwalkdir.go
+++ b/pkg/pwalkdir/pwalkdir.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package pwalkdir
@@ -51,6 +52,9 @@ func WalkN(root string, walkFn fs.WalkDirFunc, num int) error {
 	var (
 		err error
 		wg  sync.WaitGroup
+
+		rootLen   = len(root)
+		rootEntry *walkArgs
 	)
 	wg.Add(1)
 	go func() {
@@ -58,6 +62,11 @@ func WalkN(root string, walkFn fs.WalkDirFunc, num int) error {
 			if err != nil {
 				close(files)
 				return err
+			}
+			if len(p) == rootLen {
+				// Don't add root entry just yet.
+				rootEntry = &walkArgs{path: p, entry: entry}
+				return nil
 			}
 			// Add a file to the queue unless a callback sent an error.
 			select {
@@ -70,6 +79,8 @@ func WalkN(root string, walkFn fs.WalkDirFunc, num int) error {
 			}
 		})
 		if err == nil {
+			// Finally, add the root entry.
+			files <- rootEntry
 			close(files)
 		}
 		wg.Done()

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package pwalkdir
@@ -25,8 +26,10 @@ func TestWalkDir(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	var last string
 	err = WalkN(dir,
-		func(_ string, _ fs.DirEntry, _ error) error {
+		func(p string, _ fs.DirEntry, _ error) error {
+			last = p
 			atomic.AddUint32(&count, 1)
 			return nil
 		},
@@ -37,6 +40,9 @@ func TestWalkDir(t *testing.T) {
 	}
 	if count != uint32(total) {
 		t.Errorf("File count mismatch: found %d, expected %d", count, total)
+	}
+	if last != dir {
+		t.Errorf("Last entry: want %q, got %q", dir, last)
 	}
 
 	t.Logf("concurrency: %d, files found: %d\n", concurrency, count)


### PR DESCRIPTION
Modify pwalk and pwalkdir to make sure the path itself is added last.

This adds a guarantee that Chcon/Relabel will relabel the top-level
directory (i.e. the argument) only after all its descendants are
relabeled, thus creating a possibility to do conditional relabeling.

Benchmarks showed no noticeable difference in performance.