### PR TITLE
Add LFileLabel and LSetFileLabel

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -61,14 +61,28 @@ func ClassIndex(class string) (int, error) {
 	return classIndex(class)
 }
 
-// SetFileLabel sets the SELinux label for this path or returns an error.
+// SetFileLabel sets the SELinux label for this path, following symlinks,
+// or returns an error.
 func SetFileLabel(fpath string, label string) error {
 	return setFileLabel(fpath, label)
 }
 
-// FileLabel returns the SELinux label for this path or returns an error.
+// LsetFileLabel sets the SELinux label for this path, not following symlinks,
+// or returns an error.
+func LsetFileLabel(fpath string, label string) error {
+	return lSetFileLabel(fpath, label)
+}
+
+// FileLabel returns the SELinux label for this path, following symlinks,
+// or returns an error.
 func FileLabel(fpath string) (string, error) {
 	return fileLabel(fpath)
+}
+
+// LfileLabel returns the SELinux label for this path, not following symlinks,
+// or returns an error.
+func LfileLabel(fpath string) (string, error) {
+	return lFileLabel(fpath)
 }
 
 // SetFSCreateLabel tells the kernel what label to use for all file system objects

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -17,7 +17,15 @@ func setFileLabel(fpath string, label string) error {
 	return nil
 }
 
+func lSetFileLabel(fpath string, label string) error {
+	return nil
+}
+
 func fileLabel(fpath string) (string, error) {
+	return "", nil
+}
+
+func lFileLabel(fpath string) (string, error) {
 	return "", nil
 }
 

--- a/go-selinux/xattrs_linux.go
+++ b/go-selinux/xattrs_linux.go
@@ -36,3 +36,36 @@ func doLgetxattr(path, attr string, dest []byte) (int, error) {
 		}
 	}
 }
+
+// getxattr returns a []byte slice containing the value of
+// an extended attribute attr set for path.
+func getxattr(path, attr string) ([]byte, error) {
+	// Start with a 128 length byte array
+	dest := make([]byte, 128)
+	sz, errno := dogetxattr(path, attr, dest)
+	for errno == unix.ERANGE { //nolint:errorlint // unix errors are bare
+		// Buffer too small, use zero-sized buffer to get the actual size
+		sz, errno = dogetxattr(path, attr, []byte{})
+		if errno != nil {
+			return nil, errno
+		}
+
+		dest = make([]byte, sz)
+		sz, errno = dogetxattr(path, attr, dest)
+	}
+	if errno != nil {
+		return nil, errno
+	}
+
+	return dest[:sz], nil
+}
+
+// dogetxattr is a wrapper that retries on EINTR
+func dogetxattr(path, attr string, dest []byte) (int, error) {
+	for {
+		sz, err := unix.Getxattr(path, attr, dest)
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return sz, err
+		}
+	}
+}


### PR DESCRIPTION
SELinux C library has two functions for dealing with file labels, one
which follows symlinks and one that does not.

Golang bindings should work the same way.  The lack of this function is
resulting in https://github.com/containers/buildah/pull/3630 which has
to hack around the problem.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>