### PR TITLE
If chcon fails, check if label is already correct

### DIFF
--- a/go-selinux/rchcon.go
+++ b/go-selinux/rchcon.go
@@ -12,7 +12,18 @@ import (
 )
 
 func rchcon(fpath, label string) error {
+	fastMode := false
+	// If the current label matches the new label, assume
+	// other labels are correct.
+	if cLabel, err := lFileLabel(fpath); err == nil && cLabel == label {
+		fastMode = true
+	}
 	return pwalkdir.Walk(fpath, func(p string, _ fs.DirEntry, _ error) error {
+		if fastMode {
+			if cLabel, err := lFileLabel(fpath); err == nil && cLabel == label {
+				return nil
+			}
+		}
 		e := lSetFileLabel(p, label)
 		// Walk a file tree can race with removal, so ignore ENOENT.
 		if errors.Is(e, os.ErrNotExist) {


### PR DESCRIPTION
Currently if a user attempts to chcon a file or directory and fails for
any reason check if the file already has the right label, and continue.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>