### PR TITLE
Allow relabeling of files/directories under /usr prefix

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -1072,21 +1072,6 @@ func copyLevel(src, dest string) (string, error) {
 	return tcon.Get(), nil
 }
 
-// Prevent users from relabeling system files
-func badPrefix(fpath string) error {
-	if fpath == "" {
-		return ErrEmptyPath
-	}
-
-	badPrefixes := []string{"/usr"}
-	for _, prefix := range badPrefixes {
-		if strings.HasPrefix(fpath, prefix) {
-			return fmt.Errorf("relabeling content in %s is not allowed", prefix)
-		}
-	}
-	return nil
-}
-
 // chcon changes the fpath file object to the SELinux label label.
 // If fpath is a directory and recurse is true, then chcon walks the
 // directory tree setting the label.
@@ -1096,9 +1081,6 @@ func chcon(fpath string, label string, recurse bool) error {
 	}
 	if label == "" {
 		return nil
-	}
-	if err := badPrefix(fpath); err != nil {
-		return err
 	}
 
 	if !recurse {


### PR DESCRIPTION
We already check to make sure users do not accidentily relabel these excluded paths:

	exclude_paths := map[string]bool{
		"/":           true,
		"/bin":        true,
		"/boot":       true,
		"/dev":        true,
		"/etc":        true,
		"/etc/passwd": true,
		"/etc/pki":    true,
		"/etc/shadow": true,
		"/home":       true,
		"/lib":        true,
		"/lib64":      true,
		"/media":      true,
		"/opt":        true,
		"/proc":       true,
		"/root":       true,
		"/run":        true,
		"/sbin":       true,
		"/srv":        true,
		"/sys":        true,
		"/tmp":        true,
		"/usr":        true,
		"/var":        true,
		"/var/lib":    true,
		"/var/log":    true,
	}

But some users put homedirectories under /usr, and I see no reason to block them from relabeling.

At a certain point if users do something dumb with relableing we can not stop them.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>