### PR TITLE
pkg/pwalk: deprecate in favor of pkg/pwalkdir

### DIFF
--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -8,6 +8,10 @@ import (
 	"sync"
 )
 
+// WalkFunc is the type of the function called by Walk to visit each
+// file or directory. It is an alias for [filepath.WalkFunc].
+//
+// Deprecated: use [github.com/opencontainers/selinux/pkg/pwalkdir] and [fs.WalkDirFunc].
 type WalkFunc = filepath.WalkFunc
 
 // Walk is a wrapper for filepath.Walk which can call multiple walkFn
@@ -29,6 +33,8 @@ type WalkFunc = filepath.WalkFunc
 // - if more than one walkFn instance will return an error, only one
 // of such errors will be propagated and returned by Walk, others
 // will be silently discarded.
+//
+// Deprecated: use [github.com/opencontainers/selinux/pkg/pwalkdir.Walk]
 func Walk(root string, walkFn WalkFunc) error {
 	return WalkN(root, walkFn, runtime.NumCPU()*2)
 }
@@ -38,6 +44,8 @@ func Walk(root string, walkFn WalkFunc) error {
 // num walkFn will be called at any one time.
 //
 // Please see Walk documentation for caveats of using this function.
+//
+// Deprecated: use [github.com/opencontainers/selinux/pkg/pwalkdir.WalkN]
 func WalkN(root string, walkFn WalkFunc, num int) error {
 	// make sure limit is sensible
 	if num < 1 {


### PR DESCRIPTION
The package was already deprecated in the README, but not in code. This patch marks the code as deprecated, as go1.15 reached EOL, so all consumers should be able to use the new package.

In a follow-up, we can make these functions an alias for the new package (or remove it altogether).
