### PR TITLE
go-selinux: remove redundant stub for DisableSecOpt()

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -284,7 +284,7 @@ func DupSecOpt(src string) ([]string, error) {
 // DisableSecOpt returns a security opt that can be used to disable SELinux
 // labeling support for future container processes.
 func DisableSecOpt() []string {
-	return disableSecOpt()
+	return []string{"disable"}
 }
 
 // GetDefaultContextWithLevel gets a single context for the specified SELinux user

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -1180,12 +1180,6 @@ func dupSecOpt(src string) ([]string, error) {
 	return dup, nil
 }
 
-// disableSecOpt returns a security opt that can be used to disable SELinux
-// labeling support for future container processes.
-func disableSecOpt() []string {
-	return []string{"disable"}
-}
-
 // findUserInContext scans the reader for a valid SELinux context
 // match that is verified with the verifier. Invalid contexts are
 // skipped. It returns a matched context or an empty string if no

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -152,10 +152,6 @@ func dupSecOpt(src string) ([]string, error) {
 	return nil, nil
 }
 
-func disableSecOpt() []string {
-	return []string{"disable"}
-}
-
 func getDefaultContextWithLevel(user, level, scon string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
Both implementations were the same, so no stub is needed.
