### PR TITLE
use filepath instead of path

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -11,7 +11,6 @@ import (
 	"math/big"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -461,10 +460,10 @@ func attrPath(attr string) string {
 	})
 
 	if haveThreadSelf {
-		return path.Join(threadSelfPrefix, attr)
+		return filepath.Join(threadSelfPrefix, attr)
 	}
 
-	return path.Join("/proc/self/task/", strconv.Itoa(unix.Gettid()), "/attr/", attr)
+	return filepath.Join("/proc/self/task", strconv.Itoa(unix.Gettid()), "attr", attr)
 }
 
 func readAttr(attr string) (string, error) {
@@ -815,7 +814,7 @@ func reserveLabel(label string) {
 }
 
 func selinuxEnforcePath() string {
-	return path.Join(getSelinuxMountPoint(), "enforce")
+	return filepath.Join(getSelinuxMountPoint(), "enforce")
 }
 
 // enforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
@@ -940,7 +939,7 @@ func openContextFile() (*os.File, error) {
 	if f, err := os.Open(contextFile); err == nil {
 		return f, nil
 	}
-	return os.Open(filepath.Join(policyRoot(), "/contexts/lxc_contexts"))
+	return os.Open(filepath.Join(policyRoot(), "contexts", "lxc_contexts"))
 }
 
 func loadLabels() {
@@ -1043,7 +1042,7 @@ func addMcs(processLabel, fileLabel string) (string, string) {
 
 // securityCheckContext validates that the SELinux label is understood by the kernel
 func securityCheckContext(val string) error {
-	return os.WriteFile(path.Join(getSelinuxMountPoint(), "context"), []byte(val), 0o644)
+	return os.WriteFile(filepath.Join(getSelinuxMountPoint(), "context"), []byte(val), 0o644)
 }
 
 // copyLevel returns a label with the MLS/MCS level from src label replaced on


### PR DESCRIPTION
Originally, this package was documented to be for paths separated by forward slashes, but I was recently pointed to the updated package description, which amended the documentation (see https://go-review.googlesource.com/32423) and added:

> To manipulate operating system paths, use the path/filepath package.

A later patch (https://go-review.googlesource.com/45653) tweaked the description again, adding to the `path/filepath` package:

> To process paths such as URLs that always use forward slashes regardless of
> the operating system, see the path package.

And to the `path` package

> This package does not deal with Windows paths with drive letters or backslashes;
> to manipulate operating system paths, use the path/filepath package.

I expect it to be "fine" in general to use the `path` package for Unix/Linux, but
from both patches, the intent of the Go maintainers is to use `path/filepath`
for anything file(system) related, so let's adapt to that.