### PR TITLE
Add Go 1.20 support; require Go 1.19; drop Go 1.17 and 1.18

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,10 +33,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50
+          version: v1.51
 
   cross:
     runs-on: ubuntu-20.04
@@ -51,10 +51,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50
+          version: v1.51
       - name: test-stubs
         run: make test
 
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.19.x, 1.20.x]
         race: ["-race", ""]
     runs-on: ubuntu-20.04
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/opencontainers/selinux
 
-go 1.17
+go 1.19
 
 require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>