### PR TITLE
Add ability to set fscontext mounts points

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -78,6 +78,9 @@ func ReleaseLabel(label string) error {
 // Deprecated: use selinux.DupSecOpt
 var DupSecOpt = selinux.DupSecOpt
 
+// FormatMountLabel returns a string to be used by the mount command. Using
+// the SELinux `context` mount option. Changing labels of files on mount
+// points with this option can never be changed.
 // FormatMountLabel returns a string to be used by the mount command.
 // The format of this string will be used to alter the labeling of the mountpoint.
 // The string returned is suitable to be used as the options field of the mount command.
@@ -85,12 +88,27 @@ var DupSecOpt = selinux.DupSecOpt
 // the first parameter.  Second parameter is the label that you wish to apply
 // to all content in the mount point.
 func FormatMountLabel(src, mountLabel string) string {
+	return FormatMountLabelByType(src, mountLabel, "context")
+}
+
+// FormatMountLabelByType returns a string to be used by the mount command.
+// Allow caller to specify the mount options. For example using the SELinux
+// `fscontext` mount option would allow certain container processes to change
+// labels of files created on the mount points, where as `context` option does
+// not.
+// FormatMountLabelByType returns a string to be used by the mount command.
+// The format of this string will be used to alter the labeling of the mountpoint.
+// The string returned is suitable to be used as the options field of the mount command.
+// If you need to have additional mount point options, you can pass them in as
+// the first parameter.  Second parameter is the label that you wish to apply
+// to all content in the mount point.
+func FormatMountLabelByType(src, mountLabel, contextType string) string {
 	if mountLabel != "" {
 		switch src {
 		case "":
-			src = fmt.Sprintf("context=%q", mountLabel)
+			src = fmt.Sprintf("%s=%q", contextType, mountLabel)
 		default:
-			src = fmt.Sprintf("%s,context=%q", src, mountLabel)
+			src = fmt.Sprintf("%s,%s=%q", src, contextType, mountLabel)
 		}
 	}
 	return src

--- a/go-selinux/label/label_test.go
+++ b/go-selinux/label/label_test.go
@@ -17,4 +17,19 @@ func TestFormatMountLabel(t *testing.T) {
 	if test := FormatMountLabel("src", ""); test != expected {
 		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
 	}
+
+	expected = `fscontext="foobar"`
+	if test := FormatMountLabelByType("", "foobar", "fscontext"); test != expected {
+		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
+	}
+
+	expected = `src,fscontext="foobar"`
+	if test := FormatMountLabelByType("src", "foobar", "fscontext"); test != expected {
+		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
+	}
+
+	expected = `src`
+	if test := FormatMountLabelByType("src", "", "rootcontext"); test != expected {
+		t.Fatalf("Format failed. Expected %s, got %s", expected, test)
+	}
 }


### PR DESCRIPTION
SELinux supports mounting file systems with multiple different file system types, adding new interface FormatMountLabelByType, allows the caller to specify the SELinux context type to mount the file system with.

Mount supports multiple different file system types.

context, fscontext, rootcontext, defcontext.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>