### PR TITLE
pwalk, pwalkdir: fix walk vs remove race

### DIFF
--- a/pkg/pwalk/README.md
+++ b/pkg/pwalk/README.md
@@ -24,6 +24,10 @@ Please note the following limitations of this code:
 
   * filepath.SkipDir is not supported;
 
+  * ErrNotExist errors from filepath.Walk are silently ignored for any path
+    except the top directory (Walk argument); any other error is returned to
+    the caller of Walk;
+
   * no errors are ever passed to WalkFunc;
 
   * once any error is returned from any WalkFunc instance, no more new calls

--- a/pkg/pwalkdir/README.md
+++ b/pkg/pwalkdir/README.md
@@ -28,7 +28,9 @@ Please note the following limitations of this code:
 
   * fs.SkipDir is not supported;
 
-  * no errors are ever passed to WalkDirFunc;
+  * ErrNotExist errors from filepath.WalkDir are silently ignored for any path
+    except the top directory (WalkDir argument); any other error is returned to
+    the caller of WalkDir;
 
   * once any error is returned from any walkDirFunc instance, no more calls
     to WalkDirFunc are made, and the error is returned to the caller of WalkDir;

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -18,20 +18,14 @@ import (
 func TestWalkDir(t *testing.T) {
 	var count uint32
 	concurrency := runtime.NumCPU() * 2
+	dir, total := prepareTestSet(t, 3, 2, 1)
 
-	dir, total, err := prepareTestSet(3, 2, 1)
-	if err != nil {
-		t.Fatalf("dataset creation failed: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	err = WalkN(dir,
+	err := WalkN(dir,
 		func(_ string, _ fs.DirEntry, _ error) error {
 			atomic.AddUint32(&count, 1)
 			return nil
 		},
 		concurrency)
-
 	if err != nil {
 		t.Errorf("Walk failed: %v", err)
 	}
@@ -45,15 +39,11 @@ func TestWalkDir(t *testing.T) {
 func TestWalkDirManyErrors(t *testing.T) {
 	var count uint32
 
-	dir, total, err := prepareTestSet(3, 3, 2)
-	if err != nil {
-		t.Fatalf("dataset creation failed: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir, total := prepareTestSet(t, 3, 3, 2)
 
 	max := uint32(total / 2)
 	e42 := errors.New("42")
-	err = Walk(dir,
+	err := Walk(dir,
 		func(p string, e fs.DirEntry, _ error) error {
 			if atomic.AddUint32(&count, 1) > max {
 				return e42
@@ -105,17 +95,22 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error)
 //
 // Total dirs: dirs^levels + dirs^(levels-1) + ... + dirs^1
 // Total files: total_dirs * files
-func prepareTestSet(levels, dirs, files int) (dir string, total int, err error) {
+func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total int) {
+	tb.Helper()
+	var err error
+
 	dir, err = os.MkdirTemp(".", "pwalk-test-")
 	if err != nil {
-		return
+		tb.Fatal(err)
 	}
+	tb.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+			tb.Errorf("cleanup error: %v", err)
+		}
+	})
 	total, err = makeManyDirs(dir, levels, dirs, files)
-	if err != nil && total > 0 {
-		_ = os.RemoveAll(dir)
-		dir = ""
-		total = 0
-		return
+	if err != nil {
+		tb.Fatal(err)
 	}
 	total++ // this dir
 
@@ -165,11 +160,7 @@ func BenchmarkWalk(b *testing.B) {
 		{name: "pwalkdir.Walk256", walker: genWalkN(256)},
 	}
 
-	dir, total, err := prepareTestSet(levels, dirs, files)
-	if err != nil {
-		b.Fatalf("dataset creation failed: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir, total := prepareTestSet(b, levels, dirs, files)
 	b.Logf("dataset: %d levels x %d dirs x %d files, total entries: %d", levels, dirs, files, total)
 
 	for _, bm := range benchmarks {


### PR DESCRIPTION
In some cases, when file walk is racing with removal, the ENOENT is
received by filepath.Walk[Dir], rather than by the callback.

Do ignore such errors, except for the root directory (Walk argument).

Modify the doc accordingly, and add a couple of test cases.

The "Race" test case, when testing the code before the fix, fails 100%
of times for pwalk and 90% for pwalkdir. Alas, I was unable to make it
fail 100% of the times without significantly increasing the test
complexity.
    
Fixes: #199
