### PR TITLE
ci: bump some actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: get pr commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.0.0
+        uses: tim-actions/get-pr-commits@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,9 +31,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
+          cache: false # golangci-lint-action does its own caching
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54
@@ -49,9 +50,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
+          cache: false # golangci-lint-action does its own caching
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54
@@ -69,9 +71,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: install go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          stable: '!contains(${{ matrix.go-version }}, "beta") && !contains(${{ matrix.go-version }}, "rc")'
           go-version: ${{ matrix.go-version }}
 
       - name: build


### PR DESCRIPTION
1. Bump actions/setup-go to v4 which enables caching by default. Disable cache for cases when golangci-lint is used.

2. Remove 'stable:' property from actions/setup-go (not needed since at least v3).

3. Bump tim-actions/get-pr-commits to v1.3.0  (fixes node compatibility).
