### PR TITLE
Show SELinux label on failure

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -329,7 +329,7 @@ func lSetFileLabel(fpath string, label string) error {
 			break
 		}
 		if err != unix.EINTR {
-			return &os.PathError{Op: "lsetxattr", Path: fpath, Err: err}
+			return &os.PathError{Op: fmt.Sprintf("lsetxattr(label=%s)", label), Path: fpath, Err: err}
 		}
 	}
 
@@ -348,7 +348,7 @@ func setFileLabel(fpath string, label string) error {
 			break
 		}
 		if err != unix.EINTR {
-			return &os.PathError{Op: "setxattr", Path: fpath, Err: err}
+			return &os.PathError{Op: fmt.Sprintf("setxattr(label=%s)", label), Path: fpath, Err: err}
 		}
 	}
 


### PR DESCRIPTION
We are seeing EINVAL errors with container engines setting SELinux labels. It would be helpful to see what Labels the engines are trying to set.