### PR TITLE
Bump Go version, deps, fix some linter issues...

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -126,3 +126,6 @@ jobs:
 
       - name: "make test"
         run: lima make -C /tmp/selinux test
+
+      - name: "32-bit test"
+        run: lima make -C /tmp/selinux GOARCH=386 test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'
     steps:
@@ -28,7 +28,7 @@ jobs:
           error: 'Subject too long (max 72)'
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -40,7 +40,7 @@ jobs:
           version: v1.56
 
   codespell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install deps
@@ -50,7 +50,7 @@ jobs:
       run: codespell
 
   cross:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: cross
@@ -76,7 +76,7 @@ jobs:
       matrix:
         go-version: [1.21.x, 1.22.x]
         race: ["-race", ""]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,10 +34,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
-          cache: false # golangci-lint-action does its own caching
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
 
   codespell:
     runs-on: ubuntu-24.04
@@ -63,10 +62,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
-          cache: false # golangci-lint-action does its own caching
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
       - name: test-stubs
         run: make test
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.19.x, 1.23.x, 1.24.x]
         race: ["-race", ""]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,10 +125,15 @@ jobs:
           lima sudo dnf install --setopt=install_weak_deps=false --setopt=tsflags=nodocs -y git-core make golang
 
       - name: "make test"
+        continue-on-error: true
         run: lima make -C /tmp/selinux test
 
       - name: "32-bit test"
+        continue-on-error: true
         run: lima make -C /tmp/selinux GOARCH=386 test
+
+      - name: "Show AVC denials"
+        run: lima sudo ausearch -m AVC,USER_AVC || true
 
   all-done:
     needs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -129,3 +129,16 @@ jobs:
 
       - name: "32-bit test"
         run: lima make -C /tmp/selinux GOARCH=386 test
+
+  all-done:
+    needs:
+      - commit
+      - lint
+      - codespell
+      - cross
+      - test-stubs
+      - test
+      - vm
+    runs-on: ubuntu-24.04
+    steps:
+    - run: echo "All jobs completed"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,12 @@
 ---
 run:
   concurrency: 6
-  deadline: 5m
+  timeout: 5m
 linters:
   enable:
+    # - copyloopvar   # Detects places where loop variables are copied. TODO enable for Go 1.22+
     - dupword       # Detects duplicate words.
     - errorlint     # Detects code that may cause problems with Go 1.13 error wrapping.
-    - exportloopref # Detects pointers to enclosing loop variables.
     - gocritic      # Metalinter; detects bugs, performance, and styling issues.
     - gofumpt       # Detects whether code was gofumpt-ed.
     - gosec         # Detects security problems.
@@ -16,13 +16,12 @@ linters:
     - prealloc      # Detects slice declarations that could potentially be pre-allocated.
     - predeclared   # Detects code that shadows one of Go's predeclared identifiers
     - revive        # Metalinter; drop-in replacement for golint.
-    - tenv          # Detects using os.Setenv instead of t.Setenv.
     - thelper       # Detects test helpers without t.Helper().
     - tparallel     # Detects inappropriate usage of t.Parallel().
     - unconvert     # Detects unnecessary type conversions.
+    - usetesting    # Reports uses of functions with replacement inside the testing package.
 linters-settings:
   govet:
-    check-shadowing: true
     enable-all: true
     settings:
       shadow:

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -584,7 +584,8 @@ func bitsetToStr(c *big.Int) string {
 	var str string
 
 	length := 0
-	for i := int(c.TrailingZeroBits()); i < c.BitLen(); i++ {
+	i0 := int(c.TrailingZeroBits()) //#nosec G115 -- don't expect TralingZeroBits to return values with highest bit set.
+	for i := i0; i < c.BitLen(); i++ {
 		if c.Bit(i) == 0 {
 			continue
 		}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -138,6 +138,7 @@ func verifySELinuxfsMount(mnt string) bool {
 		return false
 	}
 
+	//#nosec G115 -- there is no overflow here.
 	if uint32(buf.Type) != uint32(unix.SELINUX_MAGIC) {
 		return false
 	}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -45,7 +45,7 @@ type selinuxState struct {
 
 type level struct {
 	cats *big.Int
-	sens uint
+	sens int
 }
 
 type mlsRange struct {
@@ -501,14 +501,14 @@ func catsToBitset(cats string) (*big.Int, error) {
 				return nil, err
 			}
 			for i := catstart; i <= catend; i++ {
-				bitset.SetBit(bitset, int(i), 1)
+				bitset.SetBit(bitset, i, 1)
 			}
 		} else {
 			cat, err := parseLevelItem(ranges[0], category)
 			if err != nil {
 				return nil, err
 			}
-			bitset.SetBit(bitset, int(cat), 1)
+			bitset.SetBit(bitset, cat, 1)
 		}
 	}
 
@@ -516,16 +516,17 @@ func catsToBitset(cats string) (*big.Int, error) {
 }
 
 // parseLevelItem parses and verifies that a sensitivity or category are valid
-func parseLevelItem(s string, sep levelItem) (uint, error) {
+func parseLevelItem(s string, sep levelItem) (int, error) {
 	if len(s) < minSensLen || levelItem(s[0]) != sep {
 		return 0, ErrLevelSyntax
 	}
-	val, err := strconv.ParseUint(s[1:], 10, 32)
+	const bitSize = 31 // Make sure the result fits into signed int32.
+	val, err := strconv.ParseUint(s[1:], 10, bitSize)
 	if err != nil {
 		return 0, err
 	}
 
-	return uint(val), nil
+	return int(val), nil
 }
 
 // parseLevel fills a level from a string that contains
@@ -622,7 +623,7 @@ func (l *level) equal(l2 *level) bool {
 
 // String returns an mlsRange as a string.
 func (m mlsRange) String() string {
-	low := "s" + strconv.Itoa(int(m.low.sens))
+	low := "s" + strconv.Itoa(m.low.sens)
 	if m.low.cats != nil && m.low.cats.BitLen() > 0 {
 		low += ":" + bitsetToStr(m.low.cats)
 	}
@@ -631,7 +632,7 @@ func (m mlsRange) String() string {
 		return low
 	}
 
-	high := "s" + strconv.Itoa(int(m.high.sens))
+	high := "s" + strconv.Itoa(m.high.sens)
 	if m.high.cats != nil && m.high.cats.BitLen() > 0 {
 		high += ":" + bitsetToStr(m.high.cats)
 	}
@@ -640,14 +641,14 @@ func (m mlsRange) String() string {
 }
 
 // TODO: remove min and max once Go < 1.21 is not supported.
-func max(a, b uint) uint {
+func max(a, b int) int {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-func min(a, b uint) uint {
+func min(a, b int) int {
 	if a < b {
 		return a
 	}

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -640,15 +640,16 @@ func (m mlsRange) String() string {
 	return low + "-" + high
 }
 
-// TODO: remove min and max once Go < 1.21 is not supported.
-func max(a, b int) int {
+// TODO: remove these in favor of built-in min/max
+// once we stop supporting Go < 1.21.
+func maxInt(a, b int) int {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-func min(a, b int) int {
+func minInt(a, b int) int {
 	if a < b {
 		return a
 	}
@@ -677,10 +678,10 @@ func calculateGlbLub(sourceRange, targetRange string) (string, error) {
 	outrange := &mlsRange{low: &level{}, high: &level{}}
 
 	/* take the greatest of the low */
-	outrange.low.sens = max(s.low.sens, t.low.sens)
+	outrange.low.sens = maxInt(s.low.sens, t.low.sens)
 
 	/* take the least of the high */
-	outrange.high.sens = min(s.high.sens, t.high.sens)
+	outrange.high.sens = minInt(s.high.sens, t.high.sens)
 
 	/* find the intersecting categories */
 	if s.low.cats != nil && t.low.cats != nil {

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -813,8 +813,7 @@ func enforceMode() int {
 // setEnforceMode sets the current SELinux mode Enforcing, Permissive.
 // Disabled is not valid, since this needs to be set at boot time.
 func setEnforceMode(mode int) error {
-	//nolint:gosec // ignore G306: permissions to be 0600 or less.
-	return os.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0o644)
+	return os.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0)
 }
 
 // defaultEnforceMode returns the systems default SELinux mode Enforcing,
@@ -1021,8 +1020,7 @@ func addMcs(processLabel, fileLabel string) (string, string) {
 
 // securityCheckContext validates that the SELinux label is understood by the kernel
 func securityCheckContext(val string) error {
-	//nolint:gosec // ignore G306: permissions to be 0600 or less.
-	return os.WriteFile(filepath.Join(getSelinuxMountPoint(), "context"), []byte(val), 0o644)
+	return os.WriteFile(filepath.Join(getSelinuxMountPoint(), "context"), []byte(val), 0)
 }
 
 // copyLevel returns a label with the MLS/MCS level from src label replaced on

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/opencontainers/selinux
 
 go 1.19
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
+require golang.org/x/sys v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -131,22 +131,14 @@ func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total u
 	tb.Helper()
 	var err error
 
-	dir, err = os.MkdirTemp(".", "pwalk-test-")
-	if err != nil {
-		tb.Fatal(err)
-	}
-	tb.Cleanup(func() {
-		if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
-			tb.Errorf("cleanup error: %v", err)
-		}
-	})
+	dir = tb.TempDir()
 	total, err = makeManyDirs(dir, levels, dirs, files)
 	if err != nil {
 		tb.Fatal(err)
 	}
 	total++ // this dir
 
-	return
+	return dir, total
 }
 
 type walkerFunc func(root string, walkFn WalkFunc) error

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -12,21 +12,22 @@ import (
 )
 
 func TestWalk(t *testing.T) {
-	var count uint32
+	var ac atomic.Uint32
 	concurrency := runtime.NumCPU() * 2
 
 	dir, total := prepareTestSet(t, 3, 2, 1)
 
 	err := WalkN(dir,
 		func(_ string, _ os.FileInfo, _ error) error {
-			atomic.AddUint32(&count, 1)
+			ac.Add(1)
 			return nil
 		},
 		concurrency)
 	if err != nil {
 		t.Errorf("Walk failed: %v", err)
 	}
-	if count != uint32(total) {
+	count := ac.Load()
+	if count != total {
 		t.Errorf("File count mismatch: found %d, expected %d", count, total)
 	}
 
@@ -41,7 +42,7 @@ func TestWalkTopLevelErrNotExistNotIgnored(t *testing.T) {
 
 // https://github.com/opencontainers/selinux/issues/199
 func TestWalkRaceWithRemoval(t *testing.T) {
-	var count uint32
+	var ac atomic.Uint32
 	concurrency := runtime.NumCPU() * 2
 	// This test is still on a best-effort basis, meaning it can still pass
 	// when there is a bug in the code, but the larger the test set is, the
@@ -55,10 +56,11 @@ func TestWalkRaceWithRemoval(t *testing.T) {
 	go os.RemoveAll(dir)
 	err := WalkN(dir,
 		func(_ string, _ os.FileInfo, _ error) error {
-			atomic.AddUint32(&count, 1)
+			ac.Add(1)
 			return nil
 		},
 		concurrency)
+	count := int(ac.Load())
 	t.Logf("found %d of %d files", count, total)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -66,30 +68,31 @@ func TestWalkRaceWithRemoval(t *testing.T) {
 }
 
 func TestWalkDirManyErrors(t *testing.T) {
-	var count uint32
+	var ac atomic.Uint32
 
 	dir, total := prepareTestSet(t, 3, 3, 2)
 
-	max := uint32(total / 2)
+	maxFiles := total / 2
 	e42 := errors.New("42")
 	err := Walk(dir,
 		func(_ string, _ os.FileInfo, _ error) error {
-			if atomic.AddUint32(&count, 1) > max {
+			if ac.Add(1) > maxFiles {
 				return e42
 			}
 			return nil
 		})
+	count := ac.Load()
 	t.Logf("found %d of %d files", count, total)
 
 	if err == nil {
 		t.Errorf("Walk succeeded, but error is expected")
-		if count != uint32(total) {
+		if count != total {
 			t.Errorf("File count mismatch: found %d, expected %d", count, total)
 		}
 	}
 }
 
-func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error) {
+func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err error) {
 	for d := 0; d < dirs; d++ {
 		var dir string
 		dir, err = os.MkdirTemp(prefix, "d-")
@@ -109,7 +112,7 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error)
 		if levels == 0 {
 			continue
 		}
-		var c int
+		var c uint32
 		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
 			return
 		}
@@ -124,7 +127,7 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error)
 //
 // Total dirs: dirs^levels + dirs^(levels-1) + ... + dirs^1
 // Total files: total_dirs * files
-func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total int) {
+func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total uint32) {
 	tb.Helper()
 	var err error
 

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -134,22 +134,14 @@ func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total u
 	tb.Helper()
 	var err error
 
-	dir, err = os.MkdirTemp(".", "pwalk-test-")
-	if err != nil {
-		tb.Fatal(err)
-	}
-	tb.Cleanup(func() {
-		if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
-			tb.Errorf("cleanup error: %v", err)
-		}
-	})
+	dir = tb.TempDir()
 	total, err = makeManyDirs(dir, levels, dirs, files)
 	if err != nil {
 		tb.Fatal(err)
 	}
 	total++ // this dir
 
-	return
+	return dir, total
 }
 
 type walkerFunc func(root string, walkFn fs.WalkDirFunc) error

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -16,20 +16,21 @@ import (
 )
 
 func TestWalkDir(t *testing.T) {
-	var count uint32
+	var ac atomic.Uint32
 	concurrency := runtime.NumCPU() * 2
 	dir, total := prepareTestSet(t, 3, 2, 1)
 
 	err := WalkN(dir,
 		func(_ string, _ fs.DirEntry, _ error) error {
-			atomic.AddUint32(&count, 1)
+			ac.Add(1)
 			return nil
 		},
 		concurrency)
 	if err != nil {
 		t.Errorf("Walk failed: %v", err)
 	}
-	if count != uint32(total) {
+	count := ac.Load()
+	if count != total {
 		t.Errorf("File count mismatch: found %d, expected %d", count, total)
 	}
 
@@ -45,7 +46,7 @@ func TestWalkDirTopLevelErrNotExistNotIgnored(t *testing.T) {
 
 // https://github.com/opencontainers/selinux/issues/199
 func TestWalkDirRaceWithRemoval(t *testing.T) {
-	var count uint32
+	var ac atomic.Uint32
 	concurrency := runtime.NumCPU() * 2
 	// This test is still on a best-effort basis, meaning it can still pass
 	// when there is a bug in the code, but the larger the test set is, the
@@ -59,10 +60,11 @@ func TestWalkDirRaceWithRemoval(t *testing.T) {
 	go os.RemoveAll(dir)
 	err := WalkN(dir,
 		func(_ string, _ fs.DirEntry, _ error) error {
-			atomic.AddUint32(&count, 1)
+			ac.Add(1)
 			return nil
 		},
 		concurrency)
+	count := ac.Load()
 	t.Logf("found %d of %d files", count, total)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -70,29 +72,30 @@ func TestWalkDirRaceWithRemoval(t *testing.T) {
 }
 
 func TestWalkDirManyErrors(t *testing.T) {
-	var count uint32
+	var ac atomic.Uint32
 	dir, total := prepareTestSet(t, 3, 3, 2)
 
-	max := uint32(total / 2)
+	maxFiles := total / 2
 	e42 := errors.New("42")
 	err := Walk(dir,
 		func(_ string, _ fs.DirEntry, _ error) error {
-			if atomic.AddUint32(&count, 1) > max {
+			if ac.Add(1) > maxFiles {
 				return e42
 			}
 			return nil
 		})
+	count := ac.Load()
 	t.Logf("found %d of %d files", count, total)
 
 	if err == nil {
 		t.Error("Walk succeeded, but error is expected")
-		if count != uint32(total) {
+		if count != total {
 			t.Errorf("File count mismatch: found %d, expected %d", count, total)
 		}
 	}
 }
 
-func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error) {
+func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err error) {
 	for d := 0; d < dirs; d++ {
 		var dir string
 		dir, err = os.MkdirTemp(prefix, "d-")
@@ -112,7 +115,7 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error)
 		if levels == 0 {
 			continue
 		}
-		var c int
+		var c uint32
 		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
 			return
 		}
@@ -127,7 +130,7 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error)
 //
 // Total dirs: dirs^levels + dirs^(levels-1) + ... + dirs^1
 // Total files: total_dirs * files
-func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total int) {
+func prepareTestSet(tb testing.TB, levels, dirs, files int) (dir string, total uint32) {
 	tb.Helper()
 	var err error
 


### PR DESCRIPTION
This started as a bump of some CI deps but quickly got out of hand 😬 

See individual commits for details. High level overview:
- ci: bump ubuntu to 24.04 (see https://github.com/actions/runner-images/issues/11101);
- ~~go.mod: bump go to 1.21, drop min/max functions;~~
- ci: add go 1.19, 1.23, 1.24, drop go 1.21, 1.22 from test matrix;
- fix or silence new gosec warnings (these commits need to be reviewed carefully);
- ci: bump golangci-lint to v1.64, fix golangci-lint jobs caching;
- ci: add 32-bit tests;
- ci: add `all-done` job;
- go.mod: bump to `golang.org/x/sys v0.1.0`;
- ci: show avc denials after tests.