### PR TITLE
label: remove deprecated stuff

### DIFF
--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -6,77 +6,10 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-// Deprecated: use selinux.ROFileLabel
-var ROMountLabel = selinux.ROFileLabel
-
-// SetProcessLabel takes a process label and tells the kernel to assign the
-// label to the next program executed by the current process.
-// Deprecated: use selinux.SetExecLabel
-var SetProcessLabel = selinux.SetExecLabel
-
-// ProcessLabel returns the process label that the kernel will assign
-// to the next program executed by the current process.  If "" is returned
-// this indicates that the default labeling will happen for the process.
-// Deprecated: use selinux.ExecLabel
-var ProcessLabel = selinux.ExecLabel
-
-// SetSocketLabel takes a process label and tells the kernel to assign the
-// label to the next socket that gets created
-// Deprecated: use selinux.SetSocketLabel
-var SetSocketLabel = selinux.SetSocketLabel
-
-// SocketLabel retrieves the current default socket label setting
-// Deprecated: use selinux.SocketLabel
-var SocketLabel = selinux.SocketLabel
-
-// SetKeyLabel takes a process label and tells the kernel to assign the
-// label to the next kernel keyring that gets created
-// Deprecated: use selinux.SetKeyLabel
-var SetKeyLabel = selinux.SetKeyLabel
-
-// KeyLabel retrieves the current default kernel keyring label setting
-// Deprecated: use selinux.KeyLabel
-var KeyLabel = selinux.KeyLabel
-
-// FileLabel returns the label for specified path
-// Deprecated: use selinux.FileLabel
-var FileLabel = selinux.FileLabel
-
-// PidLabel will return the label of the process running with the specified pid
-// Deprecated: use selinux.PidLabel
-var PidLabel = selinux.PidLabel
-
 // Init initialises the labeling system
 func Init() {
 	_ = selinux.GetEnabled()
 }
-
-// ClearLabels will clear all reserved labels
-// Deprecated: use selinux.ClearLabels
-var ClearLabels = selinux.ClearLabels
-
-// ReserveLabel will record the fact that the MCS label has already been used.
-// This will prevent InitLabels from using the MCS label in a newly created
-// container
-// Deprecated: use selinux.ReserveLabel
-func ReserveLabel(label string) error {
-	selinux.ReserveLabel(label)
-	return nil
-}
-
-// ReleaseLabel will remove the reservation of the MCS label.
-// This will allow InitLabels to use the MCS label in a newly created
-// containers
-// Deprecated: use selinux.ReleaseLabel
-func ReleaseLabel(label string) error {
-	selinux.ReleaseLabel(label)
-	return nil
-}
-
-// DupSecOpt takes a process label and returns security options that
-// can be used to set duplicate labels on future container processes
-// Deprecated: use selinux.DupSecOpt
-var DupSecOpt = selinux.DupSecOpt
 
 // FormatMountLabel returns a string to be used by the mount command. Using
 // the SELinux `context` mount option. Changing labels of files on mount

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -79,12 +79,6 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 	return processLabel, mountLabel, nil
 }
 
-// Deprecated: The GenLabels function is only to be used during the transition
-// to the official API. Use InitLabels(strings.Fields(options)) instead.
-func GenLabels(options string) (string, string, error) {
-	return InitLabels(strings.Fields(options))
-}
-
 // SetFileLabel modifies the "path" label to the specified file label
 func SetFileLabel(path string, fileLabel string) error {
 	if !selinux.GetEnabled() || fileLabel == "" {
@@ -122,11 +116,6 @@ func Relabel(path string, fileLabel string, shared bool) error {
 	}
 	return selinux.Chcon(path, fileLabel, true)
 }
-
-// DisableSecOpt returns a security opt that can disable labeling
-// support for future container processes
-// Deprecated: use selinux.DisableSecOpt
-var DisableSecOpt = selinux.DisableSecOpt
 
 // Validate checks that the label does not include unexpected options
 func Validate(label string) error {

--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -3,7 +3,6 @@ package label
 import (
 	"errors"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -25,9 +24,8 @@ func TestInit(t *testing.T) {
 		t.Fatalf("InitLabels failed: %v:", err)
 	}
 	testDisabled := []string{"disable"}
-	roMountLabel := ROMountLabel()
-	if roMountLabel == "" {
-		t.Fatal("ROMountLabel: empty")
+	if selinux.ROFileLabel() == "" {
+		t.Fatal("selinux.ROFileLabel: empty")
 	}
 	plabel, mlabel, err := InitLabels(testDisabled)
 	if err != nil {
@@ -52,45 +50,6 @@ func TestInit(t *testing.T) {
 	testBadData := []string{"user", "role:user_r", "type:user_t", "level:s0:c1,c15"}
 	if _, _, err = InitLabels(testBadData); err == nil {
 		t.Fatal("InitLabels(bad): expected error, got nil")
-	}
-}
-
-func TestDuplicateLabel(t *testing.T) {
-	secopt, err := DupSecOpt("system_u:system_r:container_t:s0:c1,c2")
-	if err != nil {
-		t.Fatalf("DupSecOpt: %v", err)
-	}
-	for _, opt := range secopt {
-		con := strings.SplitN(opt, ":", 2)
-		if con[0] == "user" {
-			if con[1] != "system_u" {
-				t.Errorf("DupSecOpt Failed user incorrect")
-			}
-			continue
-		}
-		if con[0] == "role" {
-			if con[1] != "system_r" {
-				t.Errorf("DupSecOpt Failed role incorrect")
-			}
-			continue
-		}
-		if con[0] == "type" {
-			if con[1] != "container_t" {
-				t.Errorf("DupSecOpt Failed type incorrect")
-			}
-			continue
-		}
-		if con[0] == "level" {
-			if con[1] != "s0:c1,c2" {
-				t.Errorf("DupSecOpt Failed level incorrect")
-			}
-			continue
-		}
-		t.Errorf("DupSecOpt failed: invalid field %q", con[0])
-	}
-	secopt = DisableSecOpt()
-	if secopt[0] != "disable" {
-		t.Errorf("DisableSecOpt failed: expected \"disable\", got %q", secopt[0])
 	}
 }
 
@@ -154,59 +113,6 @@ func TestIsShared(t *testing.T) {
 	}
 	if shared := IsShared("Zz"); !shared {
 		t.Fatalf("Expected label `Zz` to be shared, got %v", shared)
-	}
-}
-
-func TestSELinuxNoLevel(t *testing.T) {
-	needSELinux(t)
-
-	tlabel := "system_u:system_r:container_t"
-	dup, err := DupSecOpt(tlabel)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(dup) != 3 {
-		t.Errorf("DupSecOpt failed on non mls label: expected 3, got %d", len(dup))
-	}
-	con, err := selinux.NewContext(tlabel)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if con.Get() != tlabel {
-		t.Errorf("NewContaxt and con.Get() failed on non mls label: expected %q, got %q", tlabel, con.Get())
-	}
-}
-
-func TestSocketLabel(t *testing.T) {
-	needSELinux(t)
-
-	label := "system_u:object_r:container_t:s0:c1,c2"
-	if err := selinux.SetSocketLabel(label); err != nil {
-		t.Fatal(err)
-	}
-	nlabel, err := selinux.SocketLabel()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if label != nlabel {
-		t.Errorf("SocketLabel %s != %s", nlabel, label)
-	}
-}
-
-func TestKeyLabel(t *testing.T) {
-	needSELinux(t)
-
-	label := "system_u:object_r:container_t:s0:c1,c2"
-	if err := selinux.SetKeyLabel(label); err != nil {
-		t.Fatal(err)
-	}
-	nlabel, err := selinux.KeyLabel()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if label != nlabel {
-		t.Errorf("KeyLabel %s != %s", nlabel, label)
 	}
 }
 

--- a/go-selinux/label/label_stub.go
+++ b/go-selinux/label/label_stub.go
@@ -10,12 +10,6 @@ func InitLabels([]string) (string, string, error) {
 	return "", "", nil
 }
 
-// Deprecated: The GenLabels function is only to be used during the transition
-// to the official API. Use InitLabels(strings.Fields(options)) instead.
-func GenLabels(string) (string, string, error) {
-	return "", "", nil
-}
-
 func SetFileLabel(string, string) error {
 	return nil
 }

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -3,7 +3,11 @@
 
 package label
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/opencontainers/selinux/go-selinux"
+)
 
 const testLabel = "system_u:object_r:container_file_t:s0:c1,c2"
 
@@ -15,9 +19,8 @@ func TestInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	testDisabled := []string{"disable"}
-	roMountLabel := ROMountLabel()
-	if roMountLabel != "" {
-		t.Errorf("ROMountLabel Failed")
+	if selinux.ROFileLabel() != "" {
+		t.Error("selinux.ROFileLabel Failed")
 	}
 	plabel, mlabel, err := InitLabels(testDisabled)
 	if err != nil {
@@ -44,45 +47,12 @@ func TestRelabel(t *testing.T) {
 	}
 }
 
-func TestSocketLabel(t *testing.T) {
-	label := testLabel
-	if err := SetSocketLabel(label); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := SocketLabel(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestKeyLabel(t *testing.T) {
-	label := testLabel
-	if err := SetKeyLabel(label); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := KeyLabel(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestProcessLabel(t *testing.T) {
-	label := testLabel
-	if err := SetProcessLabel(label); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := ProcessLabel(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestCheckLabelCompile(t *testing.T) {
-	if _, _, err := GenLabels(""); err != nil {
+	if _, _, err := InitLabels(nil); err != nil {
 		t.Fatal(err)
 	}
 
 	tmpDir := t.TempDir()
-	if _, err := FileLabel(tmpDir); err != nil {
-		t.Fatal(err)
-	}
 
 	if err := SetFileLabel(tmpDir, "foobar"); err != nil {
 		t.Fatal(err)
@@ -92,21 +62,6 @@ func TestCheckLabelCompile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := PidLabel(0); err != nil {
-		t.Fatal(err)
-	}
-
-	ClearLabels()
-
-	if err := ReserveLabel("foobar"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := ReleaseLabel("foobar"); err != nil {
-		t.Fatal(err)
-	}
-
-	_, _ = DupSecOpt("foobar")
 	DisableSecOpt()
 
 	if err := Validate("foobar"); err != nil {


### PR DESCRIPTION
This was mostly deprecated in 2020 and I was not able to find any existing users (except for very old vendor directories in a dozen of unmaintained repos).

Time to move on.