### PR TITLE
Switch to golangci-lint v2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,10 +33,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
-      - uses: golangci/golangci-lint-action@v6
+          go-version: 1.24.x
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
 
   codespell:
     runs-on: ubuntu-24.04
@@ -61,10 +61,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
-      - uses: golangci/golangci-lint-action@v6
+          go-version: 1.24.x
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
       - name: test-stubs
         run: make test
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
----
-run:
-  concurrency: 6
-  timeout: 5m
+version: "2"
+
+formatters:
+  enable:
+    - gofumpt
+
 linters:
   enable:
     # - copyloopvar   # Detects places where loop variables are copied. TODO enable for Go 1.22+
     - dupword       # Detects duplicate words.
     - errorlint     # Detects code that may cause problems with Go 1.13 error wrapping.
     - gocritic      # Metalinter; detects bugs, performance, and styling issues.
-    - gofumpt       # Detects whether code was gofumpt-ed.
     - gosec         # Detects security problems.
     - misspell      # Detects commonly misspelled English words in comments.
     - nilerr        # Detects code that returns nil even if it checks that the error is not nil.
@@ -20,16 +21,24 @@ linters:
     - tparallel     # Detects inappropriate usage of t.Parallel().
     - unconvert     # Detects unnecessary type conversions.
     - usetesting    # Reports uses of functions with replacement inside the testing package.
-linters-settings:
-  govet:
-    enable-all: true
-    settings:
-      shadow:
-        strict: true
+  settings:
+    govet:
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - govet
+        text: '^shadow: declaration of "err" shadows declaration'
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - text: '^shadow: declaration of "err" shadows declaration'
-      linters:
-        - govet

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -18,7 +18,7 @@ var validOptions = map[string]bool{
 	"level":    true,
 }
 
-var ErrIncompatibleLabel = errors.New("Bad SELinux option z and Z can not be used together")
+var ErrIncompatibleLabel = errors.New("bad SELinux option: z and Z can not be used together")
 
 // InitLabels returns the process label and file labels to be used within
 // the container.  A list of options can be passed into this function to alter
@@ -52,11 +52,11 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 				return "", selinux.PrivContainerMountLabel(), nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
+				return "", "", fmt.Errorf("bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
 			}
 			con := strings.SplitN(opt, ":", 2)
 			if !validOptions[con[0]] {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
+				return "", "", fmt.Errorf("bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
 			}
 			if con[0] == "filetype" {
 				mcon["type"] = con[1]


### PR DESCRIPTION
The configuration was migrated using golangci-lint migrate and when
tweaked manually trying to minimize it.

Also, fix some new warnings reported by updated staticcheck.
    

