### PR TITLE
keyring: fix typo in EACCES check

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -735,7 +735,7 @@ func setKeyLabel(label string) error {
 	if label == "" && errors.Is(err, os.ErrPermission) {
 		return nil
 	}
-	if errors.Is(err, unix.EACCES) && unix.Getuid() != unix.Gettid() {
+	if errors.Is(err, unix.EACCES) && unix.Getpid() != unix.Gettid() {
 		return ErrNotTGLeader
 	}
 	return err


### PR DESCRIPTION
Commit 965323e01c4e ("SetKeyLabel: add thread group leader requirement")
added verification that the caller of SetKeyLabel is the thread-group
leader, however the check had a typo in it, which would almost always
cause all errors to be treated as ErrNotTGLeader.

It's a bit of a shame that os.Getuid() and os.Getpid() are untyped, as a
one-character typo like this can really easily cause bugs without type
checking...

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>