### PR TITLE
Add Go 1.25, drop go 1.23, bump golangci-lint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,9 +34,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.5
 
   codespell:
     runs-on: ubuntu-24.04
@@ -62,9 +62,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.5
       - name: test-stubs
         run: make test
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.5
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.5
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.23.x, 1.24.x]
+        go-version: [1.19.x, 1.24.x, 1.25.x]
         race: ["-race", ""]
     runs-on: ubuntu-24.04
     steps:

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -97,7 +97,7 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err err
 		var dir string
 		dir, err = os.MkdirTemp(prefix, "d-")
 		if err != nil {
-			return
+			return count, err
 		}
 		count++
 		for f := 0; f < files; f++ {
@@ -114,12 +114,12 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err err
 		}
 		var c uint32
 		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
-			return
+			return count, err
 		}
 		count += c
 	}
 
-	return
+	return count, err
 }
 
 // prepareTestSet() creates a directory tree of shallow files,

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -100,7 +100,7 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err err
 		var dir string
 		dir, err = os.MkdirTemp(prefix, "d-")
 		if err != nil {
-			return
+			return count, err
 		}
 		count++
 		for f := 0; f < files; f++ {
@@ -117,12 +117,12 @@ func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err err
 		}
 		var c uint32
 		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
-			return
+			return count, err
 		}
 		count += c
 	}
 
-	return
+	return count, err
 }
 
 // prepareTestSet() creates a directory tree of shallow files,


### PR DESCRIPTION
See individual commits for details.

Closes: #231.