### PR TITLE
Update build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@
 
 version: 2
 updates:
-  # Dependencies listed in .github/workflows/*.yml
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - name: get pr commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.3.1
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d  # v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.2
+        uses: tim-actions/commit-message-checker-with-regex@094fc16ff83d04e2ec73edb5eaf6aa267db33791  # v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'
@@ -30,18 +30,18 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version: 1.25.x
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47  # v9.0.0
         with:
-          version: v2.5
+          version: v2.6
 
   codespell:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell
@@ -51,20 +51,20 @@ jobs:
   cross:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: cross
         run: make build-cross
 
   test-stubs:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version: 1.25.x
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47  # v9.0.0
         with:
-          version: v2.5
+          version: v2.6
       - name: test-stubs
         run: make test
 
@@ -72,14 +72,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x]
         race: ["-race", ""]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: install go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -101,14 +101,14 @@ jobs:
           - template://experimental/opensuse-tumbleweed
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: "Install Lima"
-        uses: lima-vm/lima-actions/setup@v1
+        uses: lima-vm/lima-actions/setup@25af04b575e17da32eb5173456ef8afaf1a76bad  # v1.1.0
         id: lima-actions-setup
 
       - name: "Cache ~/.cache/lima"
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.cache/lima
           key: lima-${{ steps.lima-actions-setup.outputs.version }}-${{ matrix.template }}

--- a/go-selinux/label/label_stub.go
+++ b/go-selinux/label/label_stub.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package label
 

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package label
 

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package selinux
 

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package selinux
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/opencontainers/selinux
 
-go 1.19
+go 1.24.0
 
 require (
 	github.com/cyphar/filepath-securejoin v0.6.0
-	golang.org/x/sys v0.26.0
+	golang.org/x/sys v0.37.0
 )
 
 require cyphar.com/go-pathrs v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,12 @@ cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcG
 github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=
 github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/pwalkdir/pwalkdir.go
+++ b/pkg/pwalkdir/pwalkdir.go
@@ -1,5 +1,4 @@
 //go:build go1.16
-// +build go1.16
 
 package pwalkdir
 

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -1,5 +1,4 @@
 //go:build go1.16
-// +build go1.16
 
 package pwalkdir
 


### PR DESCRIPTION
* Update golangci-lint to v2.6.x.
* Pin GitHub Actions to hash for supply chain security.
* Enable dependabot for Go modules.
* Bump Go modules.
* Drop support for unsupported old Go versions.
* Fixup golangci-lint issues.