### PR TITLE
fix infinite loop in SEUserByName

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -1326,18 +1326,13 @@ func getSeUserFromReader(username string, gids []string, r io.Reader, lookupGrou
 	var groupSeUser, groupLevel string
 
 	lineNum := -1
-	reader := bufio.NewReader(r)
-	for {
-		lineBytes, readErr := reader.ReadBytes('\n')
-		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) {
-				return "", "", fmt.Errorf("failed to read seusers file: %w", readErr)
-			}
-		}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		rawLine := scanner.Text()
 		lineNum++
 
 		// remove any trailing comments, then extra whitespace
-		line, _, _ := strings.Cut(string(lineBytes), "#")
+		line, _, _ := strings.Cut(rawLine, "#")
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -1377,10 +1372,9 @@ func getSeUserFromReader(username string, gids []string, r io.Reader, lookupGrou
 			defaultSeUser = seUserField
 			defaultLevel = levelField
 		}
-
-		if errors.Is(readErr, io.EOF) {
-			break
-		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", "", fmt.Errorf("failed to read seusers file: %w", err)
 	}
 
 	if groupSeUser != "" {

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -619,14 +619,15 @@ func TestGetSeUser(t *testing.T) {
 			seUserBuf: `
 system_u:system_u:s0-s15:c0.c255
 root:root:s0-s15:c0.c255
-bob:staff_u:s0-s15:c0.c255`,
+bob:staff_u:s0-s15:c0.c255
+`,
 			seUser: "staff_u",
 			level:  "s0-s15:c0.c255",
 		},
 		{
-			name:     "match with comment",
+			name:     "match with comments",
 			username: "bob",
-			seUserBuf: `
+			seUserBuf: `# bazboom
 system_u:system_u:s0-s15:c0.c255
 # foobar
 root:root:s0-s15:c0.c255
@@ -639,7 +640,8 @@ bob:staff_u:s0-s15:c0.c255 #baz`,
 			username: "bob",
 			seUserBuf: `
 system_u:system_u:s0-s15:c0.c255
-root:root:s0-s15:c0.c255`,
+root:root:s0-s15:c0.c255
+`,
 			expectedErr: `could not find SELinux user for "bob" login`,
 		},
 		{
@@ -713,6 +715,15 @@ bob:staff_u:s0-s15:c0.c255`,
 			seUserBuf: " bob:staff_u:s0  #comment   ",
 			seUser:    "staff_u",
 			level:     "s0",
+		},
+		{
+			name:     "one entry match with leading comment",
+			username: "bob",
+			seUserBuf: `# this is a comment
+bob:staff_u:s0
+`,
+			seUser: "staff_u",
+			level:  "s0",
 		},
 	}
 


### PR DESCRIPTION
The previous logic would loop forever if the last line of the `seusers` file was empty or only contained whitespace, as the check on 1337 would be true. I opted to fix the issue by using a `bufio.Scanner` as using it is simpler and less error prone.