### PR TITLE
selinux_linux: fix path in execLabel() (regression in v1.13.0)

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -564,7 +564,7 @@ func pidLabel(pid int) (string, error) {
 // ExecLabel returns the SELinux label that the kernel will use for any programs
 // that are executed by the current process thread, or an error.
 func execLabel() (string, error) {
-	return readConThreadSelf("exec")
+	return readConThreadSelf("attr/exec")
 }
 
 // canonicalizeContext takes a context string and writes it to the kernel

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -211,6 +211,35 @@ func TestSocketLabel(t *testing.T) {
 	}
 }
 
+func TestExecLabel(t *testing.T) {
+	if !GetEnabled() {
+		t.Skip("SELinux not enabled, skipping.")
+	}
+
+	// Ensure the thread stays the same for duration of the test.
+	// Otherwise Go runtime can switch this to a different thread,
+	// which results in EACCES in call to SetExecLabel.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const label = "system_u:object_r:container_t:s0:c1,c2"
+	if err := SetExecLabel(label); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := SetExecLabel(""); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	nlabel, err := ExecLabel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if label != nlabel {
+		t.Errorf("ExecLabel: want %q, got %q", label, nlabel)
+	}
+}
+
 func TestKeyLabel(t *testing.T) {
 	if !GetEnabled() {
 		t.Skip("SELinux not enabled, skipping.")


### PR DESCRIPTION
execLabel() was trying to read `/proc/thread-self/exec` instead of `/proc/thread-self/attr/exec`