### PR TITLE
Switch to go 1.22; modernize code

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.25.x, 1.26.x]
+        go-version: [1.22.x, 1.25.x, 1.26.x]
         race: ["-race", ""]
     runs-on: ubuntu-24.04
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ formatters:
 
 linters:
   enable:
-    # - copyloopvar   # Detects places where loop variables are copied. TODO enable for Go 1.22+
+    - copyloopvar   # Detects places where loop variables are copied.
     - dupword       # Detects duplicate words.
     - errorlint     # Detects code that may cause problems with Go 1.13 error wrapping.
     - gocritic      # Metalinter; detects bugs, performance, and styling issues.

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -51,7 +51,7 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 				selinux.ReleaseLabel(mountLabel)
 				return "", selinux.PrivContainerMountLabel(), nil
 			}
-			if i := strings.Index(opt, ":"); i == -1 {
+			if !strings.Contains(opt, ":") {
 				return "", "", fmt.Errorf("bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
 			}
 			con := strings.SplitN(opt, ":", 2)

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -83,26 +83,15 @@ const (
 
 var (
 	readOnlyFileLabel string
-	state             = selinuxState{
+
+	state = selinuxState{
 		mcsList: make(map[string]bool),
 	}
-
-	// for policyRoot()
-	policyRootOnce sync.Once
-	policyRootVal  string
-
-	// for label()
-	loadLabelsOnce sync.Once
-	labels         map[string]string
 )
 
-func policyRoot() string {
-	policyRootOnce.Do(func() {
-		policyRootVal = filepath.Join(selinuxDir, readConfig(selinuxTypeTag))
-	})
-
-	return policyRootVal
-}
+var policyRoot = sync.OnceValue(func() string {
+	return filepath.Join(selinuxDir, readConfig(selinuxTypeTag))
+})
 
 func (s *selinuxState) setEnable(enabled bool) bool {
 	s.Lock()
@@ -1032,11 +1021,11 @@ func openContextFile() (*os.File, error) {
 	return os.Open(filepath.Join(policyRoot(), "contexts", "lxc_contexts"))
 }
 
-func loadLabels() {
-	labels = make(map[string]string)
+var loadLabels = sync.OnceValue(func() map[string]string {
+	labels := make(map[string]string)
 	in, err := openContextFile()
 	if err != nil {
-		return
+		return labels
 	}
 	defer in.Close()
 
@@ -1064,13 +1053,11 @@ func loadLabels() {
 	con["level"] = fmt.Sprintf("s0:c%d,c%d", maxCategory-2, maxCategory-1)
 	privContainerMountLabel = con.get()
 	reserveLabel(privContainerMountLabel)
-}
+	return labels
+})
 
 func label(key string) string {
-	loadLabelsOnce.Do(func() {
-		loadLabels()
-	})
-	return labels[key]
+	return loadLabels()[key]
 }
 
 // kvmContainerLabels returns the default processLabel and mountLabel to be used

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -742,22 +743,6 @@ func (m mlsRange) String() string {
 	return low + "-" + high
 }
 
-// TODO: remove these in favor of built-in min/max
-// once we stop supporting Go < 1.21.
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // calculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
 // of a source and target range.
 // The glblub is calculated as the greater of the low sensitivities and
@@ -780,10 +765,10 @@ func calculateGlbLub(sourceRange, targetRange string) (string, error) {
 	outrange := &mlsRange{low: &level{}, high: &level{}}
 
 	/* take the greatest of the low */
-	outrange.low.sens = maxInt(s.low.sens, t.low.sens)
+	outrange.low.sens = max(s.low.sens, t.low.sens)
 
 	/* take the least of the high */
-	outrange.high.sens = minInt(s.high.sens, t.high.sens)
+	outrange.high.sens = min(s.high.sens, t.high.sens)
 
 	/* find the intersecting categories */
 	if s.low.cats != nil && t.low.cats != nil {
@@ -1312,12 +1297,7 @@ func checkGroup(group string, gids []string, lookupGroup func(string) (*user.Gro
 		return false
 	}
 
-	for _, gid := range gids {
-		if grp.Gid == gid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(gids, grp.Gid)
 }
 
 // getSeUserFromReader reads the seusers file: https://www.man7.org/linux/man-pages/man5/seusers.5.html

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -595,13 +595,6 @@ func TestGlbLub(t *testing.T) {
 	for _, tt := range tests {
 		got, err := CalculateGlbLub(tt.sourceRange, tt.targetRange)
 		if !errors.Is(err, tt.expectedErr) {
-			// Go 1.13 strconv errors are not unwrappable,
-			// so do that manually.
-			// TODO remove this once we stop supporting Go 1.13.
-			var numErr *strconv.NumError
-			if errors.As(err, &numErr) && numErr.Err == tt.expectedErr { //nolint:errorlint // see above
-				continue
-			}
 			t.Fatalf("want %q got %q: src: %q tgt: %q", tt.expectedErr, err, tt.sourceRange, tt.targetRange)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/selinux
 
-go 1.19
+go 1.22
 
 require (
 	github.com/cyphar/filepath-securejoin v0.5.1

--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -100,7 +100,7 @@ func WalkN(root string, walkFn WalkFunc, num int) error {
 	}()
 
 	wg.Add(num)
-	for i := 0; i < num; i++ {
+	for range num {
 		go func() {
 			for file := range files {
 				if e := walkFn(file.path, *file.info, nil); e != nil {

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -93,14 +93,14 @@ func TestWalkDirManyErrors(t *testing.T) {
 }
 
 func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err error) {
-	for d := 0; d < dirs; d++ {
+	for range dirs {
 		var dir string
 		dir, err = os.MkdirTemp(prefix, "d-")
 		if err != nil {
 			return count, err
 		}
 		count++
-		for f := 0; f < files; f++ {
+		for range files {
 			var fi *os.File
 			fi, err = os.CreateTemp(dir, "f-")
 			if err != nil {

--- a/pkg/pwalkdir/pwalkdir.go
+++ b/pkg/pwalkdir/pwalkdir.go
@@ -89,7 +89,7 @@ func WalkN(root string, walkFn fs.WalkDirFunc, num int) error {
 	}()
 
 	wg.Add(num)
-	for i := 0; i < num; i++ {
+	for range num {
 		go func() {
 			for file := range files {
 				if e := walkFn(file.path, file.entry, nil); e != nil {

--- a/pkg/pwalkdir/pwalkdir.go
+++ b/pkg/pwalkdir/pwalkdir.go
@@ -1,6 +1,3 @@
-//go:build go1.16
-// +build go1.16
-
 package pwalkdir
 
 import (

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -93,14 +93,14 @@ func TestWalkDirManyErrors(t *testing.T) {
 }
 
 func makeManyDirs(prefix string, levels, dirs, files int) (count uint32, err error) {
-	for d := 0; d < dirs; d++ {
+	for range dirs {
 		var dir string
 		dir, err = os.MkdirTemp(prefix, "d-")
 		if err != nil {
 			return count, err
 		}
 		count++
-		for f := 0; f < files; f++ {
+		for range files {
 			var fi *os.File
 			fi, err = os.CreateTemp(dir, "f-")
 			if err != nil {

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -1,6 +1,3 @@
-//go:build go1.16
-// +build go1.16
-
 package pwalkdir
 
 import (


### PR DESCRIPTION
Go 1.22 was released more than 2 years ago (in February 2024) and is not supported since Go 1.24 is out (February 2025).

I think we can switch to it as a minimally required version, and apply some new language and stdlib features.

See individual commits for details.

~~Draft until #255 is merged.~~