### PR TITLE
Use math/rand/v2 rather than crypto/rand

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   enable:
     - copyloopvar   # Detects places where loop variables are copied.
     - dupword       # Detects duplicate words.
+    - depguard      # Allows or rejects certain package imports.
     - errorlint     # Detects code that may cause problems with Go 1.13 error wrapping.
     - gocritic      # Metalinter; detects bugs, performance, and styling issues.
     - gosec         # Detects security problems.
@@ -22,6 +23,16 @@ linters:
     - unconvert     # Detects unnecessary type conversions.
     - usetesting    # Reports uses of functions with replacement inside the testing package.
   settings:
+    depguard:
+      rules:
+        fipscompliance:
+          deny:
+            - pkg: crypto/
+              desc: Using crypto/... requires consumers to potentially have to care about FIPS compliance, so it should be avoided if possible.
+        mathrandv1:
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2.
     govet:
       enable-all: true
       settings:

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -3,13 +3,12 @@ package selinux
 import (
 	"bufio"
 	"bytes"
-	"crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"math/big"
+	"math/rand/v2"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -954,16 +953,16 @@ func mcsDelete(mcs string) {
 
 func uniqMcs(catRange uint32) string {
 	var (
-		n      uint32
 		c1, c2 uint32
 		mcs    string
 	)
 
 	for {
-		_ = binary.Read(rand.Reader, binary.LittleEndian, &n)
-		c1 = n % catRange
-		_ = binary.Read(rand.Reader, binary.LittleEndian, &n)
-		c2 = n % catRange
+		//#nosec G404 -- using slightly more predictable MCS labels won't affect security, so it's fine to use math/rand/v2 here.
+		{
+			c1 = rand.Uint32N(catRange)
+			c2 = rand.Uint32N(catRange)
+		}
 		if c1 == c2 {
 			continue
 		} else if c1 > c2 {

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -2,7 +2,7 @@ package pwalk
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -231,6 +231,6 @@ func cbReadFile(path string, info os.FileInfo, _ error) error {
 }
 
 func cbRandomSleep(_ string, _ os.FileInfo, _ error) error {
-	time.Sleep(time.Duration(rand.Intn(500)) * time.Microsecond) //nolint:gosec // ignore G404: Use of weak random number generator
+	time.Sleep(rand.N(500 * time.Microsecond)) //#nosec G404 -- this is test code
 	return nil
 }

--- a/pkg/pwalkdir/pwalkdir_test.go
+++ b/pkg/pwalkdir/pwalkdir_test.go
@@ -3,7 +3,7 @@ package pwalkdir
 import (
 	"errors"
 	"io/fs"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -231,6 +231,6 @@ func cbReadFile(path string, e fs.DirEntry, _ error) error {
 }
 
 func cbRandomSleep(_ string, _ fs.DirEntry, _ error) error {
-	time.Sleep(time.Duration(rand.Intn(500)) * time.Microsecond) //nolint:gosec // ignore G404: Use of weak random number generator
+	time.Sleep(rand.N(500 * time.Microsecond)) //#nosec G404 -- this is test code
 	return nil
 }


### PR DESCRIPTION
Since consumers of the library might want to completely avoid using crypto/... to ensure compliance with FIPS 140-3, and since using slightly more predictable MCS labels shouldn't have any effect on security, this commit replaces the one use of crypto/rand in the codebase with its equivalent in math/rand/v2.

Closes #252