### PR TITLE
Remove intToMcs

### DIFF
--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -978,26 +978,6 @@ func mcsDelete(mcs string) {
 	state.mcsList[mcs] = false
 }
 
-func intToMcs(id int, catRange uint32) string {
-	var (
-		SETSIZE = int(catRange)
-		TIER    = SETSIZE
-		ORD     = id
-	)
-
-	if id < 1 || id > 523776 {
-		return ""
-	}
-
-	for ORD > TIER {
-		ORD -= TIER
-		TIER--
-	}
-	TIER = SETSIZE - TIER
-	ORD += TIER
-	return fmt.Sprintf("s0:c%d,c%d", TIER, ORD)
-}
-
 func uniqMcs(catRange uint32) string {
 	var (
 		n      uint32

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -314,8 +314,6 @@ func TestSELinux(t *testing.T) {
 	t.Log(flabel)
 	ReleaseLabel(plabel)
 
-	pid := os.Getpid()
-	t.Logf("PID:%d MCS:%s", pid, intToMcs(pid, 1023))
 	err = SetFSCreateLabel("unconfined_u:unconfined_r:unconfined_t:s0")
 	if err != nil {
 		t.Fatal("SetFSCreateLabel failed:", err)


### PR DESCRIPTION
Since commit b03a082 ("Rework SELinux bindings to match Go Interface Standards") this function is private and is only used by a single test.

I ran the test and it did not show anything for MCS:

    selinux_linux_test.go:338: PID:3113385 MCS:

This is because PID is too high.

Most probably it was an idea to derive unique MCS categories from the container ID or something like that, but apparently that idea was ditched.

Let's ditch the code, too.