### PR TITLE
Deprecate some stuff

### DIFF
--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -30,7 +30,7 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 	if !selinux.GetEnabled() {
 		return "", "", nil
 	}
-	processLabel, mountLabel := selinux.ContainerLabels()
+	processLabel, mountLabel := selinux.ContainerLabels() //nolint:staticcheck // ContainerLabels will be moved to an internal package.
 	if processLabel == "" {
 		// processLabel is required; if empty, do nothing.
 		return processLabel, mountLabel, nil

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -71,7 +71,9 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 		if pcon["level"] != mcsLevel {
 			selinux.ReleaseLabel(processLabel)
 		}
-		selinux.ReserveLabel(p)
+		if err := selinux.ReserveLabelV2(p); err != nil {
+			return "", "", err
+		}
 		processLabel = p
 	}
 	mountLabel = mcon.Get()

--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -24,9 +24,6 @@ func TestInit(t *testing.T) {
 		t.Fatalf("InitLabels failed: %v:", err)
 	}
 	testDisabled := []string{"disable"}
-	if selinux.ROFileLabel() == "" {
-		t.Fatal("selinux.ROFileLabel: empty")
-	}
 	plabel, mlabel, err := InitLabels(testDisabled)
 	if err != nil {
 		t.Fatalf("InitLabels(disabled) failed: %v", err)

--- a/go-selinux/label/label_stub.go
+++ b/go-selinux/label/label_stub.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package label
 

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package label
 

--- a/go-selinux/label/label_stub_test.go
+++ b/go-selinux/label/label_stub_test.go
@@ -4,8 +4,6 @@ package label
 
 import (
 	"testing"
-
-	"github.com/opencontainers/selinux/go-selinux"
 )
 
 const testLabel = "system_u:object_r:container_file_t:s0:c1,c2"
@@ -18,9 +16,6 @@ func TestInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	testDisabled := []string{"disable"}
-	if selinux.ROFileLabel() != "" {
-		t.Error("selinux.ROFileLabel Failed")
-	}
 	plabel, mlabel, err := InitLabels(testDisabled)
 	if err != nil {
 		t.Log("InitLabels Disabled Failed")

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -62,7 +62,7 @@ func GetEnabled() bool {
 }
 
 // SetCategoryRange allows to adjust the upper bound of the category range.
-// It affects subsequent calls to [KVMContainerLabels] and [InitContainerLabels].
+// It affects subsequent calls to [KVMContainerLabel] and [InitContainerLabel].
 func SetCategoryRange(upper uint32) error {
 	if upper > DefaultCategoryRange {
 		return errors.New("can't have more than DefaultCategoryRange categories")
@@ -272,14 +272,30 @@ func ROFileLabel() string {
 
 // KVMContainerLabels returns the default processLabel and mountLabel to be used
 // for kvm containers by the calling process.
+//
+// Deprecated: use [KVMContainerLabel] instead.
 func KVMContainerLabels() (string, string) {
 	return kvmContainerLabels()
 }
 
+// KVMContainerLabel returns the default process label to be used
+// for KVM containers by the calling process.
+func KVMContainerLabel() (string, error) {
+	return kvmContainerLabel()
+}
+
 // InitContainerLabels returns the default processLabel and file labels to be
 // used for containers running an init system like systemd by the calling process.
+//
+// Deprecated: use [InitContainerLabel] instead.
 func InitContainerLabels() (string, string) {
 	return initContainerLabels()
+}
+
+// InitContainerLabel returns the default process label to be used
+// for containers running an init system like systemd by the calling process.
+func InitContainerLabel() (string, error) {
+	return initContainerLabel()
 }
 
 // ContainerLabels returns an allocated processLabel and fileLabel to be used for

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -40,7 +40,9 @@ var (
 	// is not the thread group leader.
 	ErrNotTGLeader = errors.New("calling thread is not the thread group leader")
 
-	// CategoryRange allows the upper bound on the category range to be adjusted
+	// CategoryRange allows the upper bound on the category range to be adjusted.
+	//
+	// Deprecated: use [SetCategoryRange] instead.
 	CategoryRange = DefaultCategoryRange
 
 	privContainerMountLabel string
@@ -57,6 +59,17 @@ func SetDisabled() {
 // GetEnabled returns whether SELinux is currently enabled.
 func GetEnabled() bool {
 	return getEnabled()
+}
+
+// SetCategoryRange allows to adjust the upper bound of the category range.
+// It affects subsequent calls to [KVMContainerLabels], [InitContainerLabels]
+// and [ContainerLabels].
+func SetCategoryRange(upper uint32) error {
+	if upper > DefaultCategoryRange {
+		return errors.New("can't have more than DefaultCategoryRange categories")
+	}
+	CategoryRange = upper
+	return nil
 }
 
 // ClassIndex returns the int index for an object class in the loaded policy,

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -263,7 +263,10 @@ func ReleaseLabel(label string) {
 	releaseLabel(label)
 }
 
-// ROFileLabel returns the specified SELinux readonly file label
+// ROFileLabel returns the specified SELinux readonly file label.
+//
+// Deprecated: this (apparently) has no users and will be removed from the
+// future version of this package. Open a bug report if you use it.
 func ROFileLabel() string {
 	return roFileLabel()
 }

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -62,8 +62,7 @@ func GetEnabled() bool {
 }
 
 // SetCategoryRange allows to adjust the upper bound of the category range.
-// It affects subsequent calls to [KVMContainerLabels], [InitContainerLabels]
-// and [ContainerLabels].
+// It affects subsequent calls to [KVMContainerLabels] and [InitContainerLabels].
 func SetCategoryRange(upper uint32) error {
 	if upper > DefaultCategoryRange {
 		return errors.New("can't have more than DefaultCategoryRange categories")
@@ -285,6 +284,9 @@ func InitContainerLabels() (string, string) {
 
 // ContainerLabels returns an allocated processLabel and fileLabel to be used for
 // container labeling by the calling process.
+//
+// Deprecated: this (apparently) has no users and will be removed from the
+// future version of this package. Open a bug report if you use it.
 func ContainerLabels() (processLabel string, fileLabel string) {
 	return containerLabels()
 }

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -223,9 +223,17 @@ func ClearLabels() {
 	clearLabels()
 }
 
-// ReserveLabel reserves the MLS/MCS level component of the specified label
+// ReserveLabel reserves the MLS/MCS level component of the specified label.
+//
+// Deprecated: use [ReserveLabelV2] instead.
 func ReserveLabel(label string) {
-	reserveLabel(label)
+	_ = reserveLabel(label)
+}
+
+// ReserveLabelV2 reserves the MLS/MCS level component of the specified label.
+// Returns an error if the label can't be reserved.
+func ReserveLabelV2(label string) error {
+	return reserveLabel(label)
 }
 
 // CheckLabel check the MLS/MCS level component of the specified label

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -817,14 +817,16 @@ func clearLabels() {
 	state.Unlock()
 }
 
-// reserveLabel reserves the MLS/MCS level component of the specified label
-func reserveLabel(label string) {
+// reserveLabel reserves the MLS/MCS level component of the specified label.
+func reserveLabel(label string) error {
 	if len(label) != 0 {
 		con := strings.SplitN(label, ":", 4)
 		if len(con) > 3 {
-			_ = mcsAdd(con[3])
+			return mcsAdd(con[3])
 		}
 	}
+
+	return nil
 }
 
 func checkLabel(label string) error {
@@ -988,7 +990,7 @@ var loadLabels = sync.OnceValue(func() map[string]string {
 	con, _ := NewContext(labels["file"])
 	con["level"] = fmt.Sprintf("s0:c%d,c%d", maxCategory-2, maxCategory-1)
 	privContainerMountLabel = con.get()
-	reserveLabel(privContainerMountLabel)
+	_ = reserveLabel(privContainerMountLabel)
 	return labels
 })
 

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -1007,6 +1007,15 @@ func kvmContainerLabels() (string, string) {
 	return addMcs(processLabel, label("file"))
 }
 
+func kvmContainerLabel() (string, error) {
+	processLabel := label("kvm_process")
+	if processLabel == "" {
+		processLabel = label("process")
+	}
+	pLabel, _, err := addMcsProc(processLabel)
+	return pLabel, err
+}
+
 // initContainerLabels returns the default processLabel and file labels to be
 // used for containers running an init system like systemd by the calling process.
 func initContainerLabels() (string, string) {
@@ -1016,6 +1025,16 @@ func initContainerLabels() (string, string) {
 	}
 
 	return addMcs(processLabel, label("file"))
+}
+
+func initContainerLabel() (string, error) {
+	processLabel := label("init_process")
+	if processLabel == "" {
+		processLabel = label("process")
+	}
+
+	pLabel, _, err := addMcsProc(processLabel)
+	return pLabel, err
 }
 
 // containerLabels returns an allocated processLabel and fileLabel to be used for
@@ -1040,13 +1059,24 @@ func containerLabels() (processLabel string, fileLabel string) {
 	return addMcs(processLabel, fileLabel)
 }
 
-func addMcs(processLabel, fileLabel string) (string, string) {
-	scon, _ := NewContext(processLabel)
+func addMcsProc(processLabel string) (string, string, error) {
+	var mcs string
+	scon, err := NewContext(processLabel)
+	if err != nil {
+		return "", "", err
+	}
 	if scon["level"] != "" {
-		mcs := uniqMcs(CategoryRange)
+		mcs = uniqMcs(CategoryRange)
 		scon["level"] = mcs
 		processLabel = scon.Get()
-		scon, _ = NewContext(fileLabel)
+	}
+	return processLabel, mcs, nil
+}
+
+func addMcs(processLabel, fileLabel string) (string, string) {
+	processLabel, mcs, _ := addMcsProc(processLabel)
+	if mcs != "" {
+		scon, _ := NewContext(fileLabel)
 		scon["level"] = mcs
 		fileLabel = scon.Get()
 	}

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -84,44 +84,37 @@ func TestSetFileLabel(t *testing.T) {
 	}
 }
 
-func TestKVMLabels(t *testing.T) {
+func TestKVMContainerLabel(t *testing.T) {
 	if !GetEnabled() {
 		t.Skip("SELinux not enabled, skipping.")
 	}
 
-	plabel, flabel := KVMContainerLabels()
-	if plabel == "" {
-		t.Log("Failed to read kvm label")
+	plabel, err := KVMContainerLabel()
+	if plabel == "" || err != nil {
+		t.Fatalf("KVMContainerLabel: got empty label (error %v)", err)
 	}
 	t.Log(plabel)
-	t.Log(flabel)
 	if _, err := CanonicalizeContext(plabel); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := CanonicalizeContext(flabel); err != nil {
 		t.Fatal(err)
 	}
 
 	ReleaseLabel(plabel)
 }
 
-func TestInitLabels(t *testing.T) {
+func TestInitContainerLabel(t *testing.T) {
 	if !GetEnabled() {
 		t.Skip("SELinux not enabled, skipping.")
 	}
 
-	plabel, flabel := InitContainerLabels()
-	if plabel == "" {
-		t.Log("Failed to read init label")
+	plabel, err := InitContainerLabel()
+	if plabel == "" || err != nil {
+		t.Fatalf("InitContainerLabel: got empty label (error %v)", err)
 	}
 	t.Log(plabel)
-	t.Log(flabel)
 	if _, err := CanonicalizeContext(plabel); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := CanonicalizeContext(flabel); err != nil {
-		t.Fatal(err)
-	}
+
 	ReleaseLabel(plabel)
 }
 

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package selinux
 

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -79,7 +79,8 @@ func newContext(string) (Context, error) {
 func clearLabels() {
 }
 
-func reserveLabel(string) {
+func reserveLabel(string) error {
+	return nil
 }
 
 func checkLabel(string) error {

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -113,8 +113,16 @@ func kvmContainerLabels() (string, string) {
 	return "", ""
 }
 
+func kvmContainerLabel() (string, error) {
+	return "", nil
+}
+
 func initContainerLabels() (string, string) {
 	return "", ""
+}
+
+func initContainerLabel() (string, error) {
+	return "", nil
 }
 
 func containerLabels() (string, string) {

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package selinux
 

--- a/go-selinux/selinux_stub_test.go
+++ b/go-selinux/selinux_stub_test.go
@@ -111,9 +111,6 @@ func TestSELinuxStubs(t *testing.T) {
 	if v := EnforceMode(); v != Disabled {
 		t.Errorf("expected %d, got %d", Disabled, v)
 	}
-	if v := ROFileLabel(); v != "" {
-		t.Errorf(`expected "", got %q`, v)
-	}
 	if processLbl, fileLbl := ContainerLabels(); processLbl != "" || fileLbl != "" {
 		t.Errorf(`expected fileLbl="", fileLbl="" got processLbl=%q, fileLbl=%q`, processLbl, fileLbl)
 	}


### PR DESCRIPTION
It turns out we need to change the API to allow some functions return errors (to fix #247).

To do that, we need to first:
 - deprecate the existing API;
 - introduce the new API.
 
 This is what this PR does. The next step (not done here yet) is major refactoring (see https://github.com/opencontainers/selinux/issues/247#issuecomment-4309556073).
 
 Please review commit by commit, see commit descriptions for more info.