### PR TITLE
[DO NOT MERGE] move selinux implementation to internal package

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,2 @@
 [codespell]
-skip = ./.git,./go.sum,./go-selinux/testdata
+skip = ./.git,./go.sum,,./internal/impl/testdata

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -147,7 +147,7 @@ jobs:
       # https://github.com/opencontainers/selinux/issues/225
       - name: "racy test"
         continue-on-error: true
-        run: lima bash -c 'cd /tmp/selinux && go test -timeout 10m -count 100000 ./go-selinux'
+        run: lima bash -c 'cd /tmp/selinux && go test -timeout 10m -count 100000 ./internal/impl'
 
       - name: "Show AVC denials"
         run: lima sudo ausearch -m AVC,USER_AVC || true

--- a/go-selinux/label/label.go
+++ b/go-selinux/label/label.go
@@ -3,12 +3,12 @@ package label
 import (
 	"fmt"
 
-	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/opencontainers/selinux/internal/impl"
 )
 
 // Init initialises the labeling system
 func Init() {
-	_ = selinux.GetEnabled()
+	_ = impl.GetEnabled()
 }
 
 // FormatMountLabel returns a string to be used by the mount command. Using

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/opencontainers/selinux/internal/impl"
 )
 
 // Valid Label Options
@@ -27,32 +27,32 @@ var ErrIncompatibleLabel = errors.New("bad SELinux option: z and Z can not be us
 // If the disabled flag is passed in, the process label will not be set, but the mount label will be set
 // to the container_file label with the maximum category. This label is not usable by any confined label.
 func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
-	if !selinux.GetEnabled() {
+	if !impl.GetEnabled() {
 		return "", "", nil
 	}
-	processLabel, mountLabel := selinux.ContainerLabels() //nolint:staticcheck // ContainerLabels will be moved to an internal package.
+	processLabel, mountLabel := impl.ContainerLabels()
 	if processLabel == "" {
 		// processLabel is required; if empty, do nothing.
 		return processLabel, mountLabel, nil
 	}
 	defer func() {
 		if retErr != nil {
-			selinux.ReleaseLabel(mountLabel)
+			impl.ReleaseLabel(mountLabel)
 		}
 	}()
-	pcon, err := selinux.NewContext(processLabel)
+	pcon, err := impl.NewContext(processLabel)
 	if err != nil {
 		return "", "", err
 	}
 	mcsLevel := pcon["level"]
-	mcon, err := selinux.NewContext(mountLabel)
+	mcon, err := impl.NewContext(mountLabel)
 	if err != nil {
 		return "", "", err
 	}
 	for _, opt := range options {
 		if opt == "disable" {
-			selinux.ReleaseLabel(mountLabel)
-			return "", selinux.PrivContainerMountLabel(), nil
+			impl.ReleaseLabel(mountLabel)
+			return "", impl.PrivContainerMountLabel(), nil
 		}
 		k, v, ok := strings.Cut(opt, ":")
 		if !ok || !validOptions[k] {
@@ -69,9 +69,9 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 	}
 	if p := pcon.Get(); p != processLabel {
 		if pcon["level"] != mcsLevel {
-			selinux.ReleaseLabel(processLabel)
+			impl.ReleaseLabel(processLabel)
 		}
-		if err := selinux.ReserveLabelV2(p); err != nil {
+		if err := impl.ReserveLabel(p); err != nil {
 			return "", "", err
 		}
 		processLabel = p
@@ -82,18 +82,18 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 
 // SetFileLabel modifies the "path" label to the specified file label
 func SetFileLabel(path string, fileLabel string) error {
-	if !selinux.GetEnabled() || fileLabel == "" {
+	if !impl.GetEnabled() || fileLabel == "" {
 		return nil
 	}
-	return selinux.SetFileLabel(path, fileLabel)
+	return impl.SetFileLabel(path, fileLabel)
 }
 
 // SetFileCreateLabel tells the kernel the label for all files to be created
 func SetFileCreateLabel(fileLabel string) error {
-	if !selinux.GetEnabled() {
+	if !impl.GetEnabled() {
 		return nil
 	}
-	return selinux.SetFSCreateLabel(fileLabel)
+	return impl.SetFSCreateLabel(fileLabel)
 }
 
 // Relabel changes the label of path and all the entries beneath the path.
@@ -102,12 +102,12 @@ func SetFileCreateLabel(fileLabel string) error {
 //
 // The path itself is guaranteed to be relabeled last.
 func Relabel(path string, fileLabel string, shared bool) error {
-	if !selinux.GetEnabled() || fileLabel == "" {
+	if !impl.GetEnabled() || fileLabel == "" {
 		return nil
 	}
 
 	if shared {
-		c, err := selinux.NewContext(fileLabel)
+		c, err := impl.NewContext(fileLabel)
 		if err != nil {
 			return err
 		}
@@ -115,7 +115,7 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		c["level"] = "s0"
 		fileLabel = c.Get()
 	}
-	return selinux.Chcon(path, fileLabel, true)
+	return impl.Chcon(path, fileLabel, true)
 }
 
 // Validate checks that the label does not include unexpected options

--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/opencontainers/selinux/internal/impl"
 )
 
 func needSELinux(t *testing.T) {
 	t.Helper()
-	if !selinux.GetEnabled() {
+	if !impl.GetEnabled() {
 		t.Skip("SELinux not enabled, skipping.")
 	}
 }

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -1,104 +1,93 @@
-package impl
+package selinux
 
 import (
-	"errors"
+	"github.com/opencontainers/selinux/internal/impl"
 )
 
 const (
 	// Enforcing constant indicate SELinux is in enforcing mode
-	Enforcing = 1
+	Enforcing = impl.Enforcing
 	// Permissive constant to indicate SELinux is in permissive mode
-	Permissive = 0
+	Permissive = impl.Permissive
 	// Disabled constant to indicate SELinux is disabled
-	Disabled = -1
-	// maxCategory is the maximum number of categories used within containers
-	maxCategory = 1024
-	// DefaultCategoryRange is the upper bound on the category range
-	DefaultCategoryRange = uint32(maxCategory)
+	Disabled = impl.Disabled
+
+	// DefaultCategoryRange is the default upper bound on the category range.
+	// See [SetCategoryRange].
+	DefaultCategoryRange = impl.DefaultCategoryRange
 )
 
 var (
 	// ErrMCSAlreadyExists is returned when trying to allocate a duplicate MCS.
-	ErrMCSAlreadyExists = errors.New("MCS label already exists")
+	ErrMCSAlreadyExists = impl.ErrMCSAlreadyExists
 	// ErrEmptyPath is returned when an empty path has been specified.
-	ErrEmptyPath = errors.New("empty path")
+	ErrEmptyPath = impl.ErrEmptyPath
 
 	// ErrInvalidLabel is returned when an invalid label is specified.
-	ErrInvalidLabel = errors.New("invalid Label")
+	ErrInvalidLabel = impl.ErrInvalidLabel
 
 	// ErrIncomparable is returned two levels are not comparable
-	ErrIncomparable = errors.New("incomparable levels")
+	ErrIncomparable = impl.ErrIncomparable
 	// ErrLevelSyntax is returned when a sensitivity or category do not have correct syntax in a level
-	ErrLevelSyntax = errors.New("invalid level syntax")
+	ErrLevelSyntax = impl.ErrLevelSyntax
 
 	// ErrContextMissing is returned if a requested context is not found in a file.
-	ErrContextMissing = errors.New("context does not have a match")
+	ErrContextMissing = impl.ErrContextMissing
 	// ErrVerifierNil is returned when a context verifier function is nil.
-	ErrVerifierNil = errors.New("verifier function is nil")
+	ErrVerifierNil = impl.ErrVerifierNil
 
 	// ErrNotTGLeader is returned by [SetKeyLabel] if the calling thread
 	// is not the thread group leader.
-	ErrNotTGLeader = errors.New("calling thread is not the thread group leader")
-
-	// CategoryRange allows the upper bound on the category range to be adjusted.
-	//
-	// Deprecated: use [SetCategoryRange] instead.
-	CategoryRange = DefaultCategoryRange
-
-	privContainerMountLabel string
+	ErrNotTGLeader = impl.ErrNotTGLeader
 )
 
 // Context is a representation of the SELinux label broken into 4 parts
-type Context map[string]string
+type Context = impl.Context
 
 // SetDisabled disables SELinux support for the package
 func SetDisabled() {
-	setDisabled()
+	impl.SetDisabled()
 }
 
 // GetEnabled returns whether SELinux is currently enabled.
 func GetEnabled() bool {
-	return getEnabled()
+	return impl.GetEnabled()
 }
 
 // SetCategoryRange allows to adjust the upper bound of the category range.
 // It affects subsequent calls to [KVMContainerLabel] and [InitContainerLabel].
 func SetCategoryRange(upper uint32) error {
-	if upper > DefaultCategoryRange {
-		return errors.New("can't have more than DefaultCategoryRange categories")
-	}
-	CategoryRange = upper
-	return nil
+	return impl.SetCategoryRange(upper)
 }
 
 // ClassIndex returns the int index for an object class in the loaded policy,
 // or -1 and an error
 func ClassIndex(class string) (int, error) {
-	return classIndex(class)
+	return impl.ClassIndex(class)
 }
 
 // SetFileLabel sets the SELinux label for this path, following symlinks,
 // or returns an error.
 func SetFileLabel(fpath string, label string) error {
-	return setFileLabel(fpath, label)
+	return impl.SetFileLabel(fpath, label)
 }
 
 // LsetFileLabel sets the SELinux label for this path, not following symlinks,
 // or returns an error.
 func LsetFileLabel(fpath string, label string) error {
-	return lSetFileLabel(fpath, label)
+	return impl.LsetFileLabel(fpath, label)
 }
 
 // FileLabel returns the SELinux label for this path, following symlinks,
 // or returns an error.
 func FileLabel(fpath string) (string, error) {
-	return fileLabel(fpath)
+	return impl.FileLabel(fpath)
 }
 
 // LfileLabel returns the SELinux label for this path, not following symlinks,
 // or returns an error.
 func LfileLabel(fpath string) (string, error) {
-	return lFileLabel(fpath)
+	return impl.LfileLabel(fpath)
 }
 
 // SetFSCreateLabel tells the kernel what label to use for all file system objects
@@ -108,42 +97,42 @@ func LfileLabel(fpath string) (string, error) {
 // objects created by this task are finished to guarantee another goroutine does not migrate
 // to the current thread before execution is complete.
 func SetFSCreateLabel(label string) error {
-	return setFSCreateLabel(label)
+	return impl.SetFSCreateLabel(label)
 }
 
 // FSCreateLabel returns the default label the kernel which the kernel is using
 // for file system objects created by this task. "" indicates default.
 func FSCreateLabel() (string, error) {
-	return ReadConThreadSelf("attr/fscreate")
+	return impl.ReadConThreadSelf("attr/fscreate")
 }
 
 // CurrentLabel returns the SELinux label of the current process thread, or an error.
 func CurrentLabel() (string, error) {
-	return ReadConThreadSelf("attr/current")
+	return impl.ReadConThreadSelf("attr/current")
 }
 
 // PidLabel returns the SELinux label of the given pid, or an error.
 func PidLabel(pid int) (string, error) {
-	return pidLabel(pid)
+	return impl.PidLabel(pid)
 }
 
 // ExecLabel returns the SELinux label that the kernel will use for any programs
 // that are executed by the current process thread, or an error.
 func ExecLabel() (string, error) {
-	return ReadConThreadSelf("attr/exec")
+	return impl.ReadConThreadSelf("attr/exec")
 }
 
 // CanonicalizeContext takes a context string and writes it to the kernel
 // the function then returns the context that the kernel will use. Use this
 // function to check if two contexts are equivalent
 func CanonicalizeContext(val string) (string, error) {
-	return canonicalizeContext(val)
+	return impl.CanonicalizeContext(val)
 }
 
 // ComputeCreateContext requests the type transition from source to target for
 // class from the kernel.
 func ComputeCreateContext(source string, target string, class string) (string, error) {
-	return computeCreateContext(source, target, class)
+	return impl.ComputeCreateContext(source, target, class)
 }
 
 // CalculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
@@ -151,7 +140,7 @@ func ComputeCreateContext(source string, target string, class string) (string, e
 // The glblub is calculated as the greater of the low sensitivities and
 // the lower of the high sensitivities and the and of each category bitset.
 func CalculateGlbLub(sourceRange, targetRange string) (string, error) {
-	return calculateGlbLub(sourceRange, targetRange)
+	return impl.CalculateGlbLub(sourceRange, targetRange)
 }
 
 // SetExecLabel sets the SELinux label that the kernel will use for any programs
@@ -160,7 +149,7 @@ func CalculateGlbLub(sourceRange, targetRange string) (string, error) {
 // of the program is finished to guarantee another goroutine does not migrate to the current
 // thread before execution is complete.
 func SetExecLabel(label string) error {
-	return WriteConThreadSelf("attr/exec", label)
+	return impl.WriteConThreadSelf("attr/exec", label)
 }
 
 // SetTaskLabel sets the SELinux label for the current thread, or an error.
@@ -168,7 +157,7 @@ func SetExecLabel(label string) error {
 // be wrapped in runtime.LockOSThread()/runtime.UnlockOSThread() to guarantee
 // the current thread does not run in a new mislabeled thread.
 func SetTaskLabel(label string) error {
-	return WriteConThreadSelf("attr/current", label)
+	return impl.WriteConThreadSelf("attr/current", label)
 }
 
 // SetSocketLabel takes a process label and tells the kernel to assign the
@@ -177,17 +166,17 @@ func SetTaskLabel(label string) error {
 // the socket is created to guarantee another goroutine does not migrate
 // to the current thread before execution is complete.
 func SetSocketLabel(label string) error {
-	return WriteConThreadSelf("attr/sockcreate", label)
+	return impl.WriteConThreadSelf("attr/sockcreate", label)
 }
 
 // SocketLabel retrieves the current socket label setting
 func SocketLabel() (string, error) {
-	return ReadConThreadSelf("attr/sockcreate")
+	return impl.ReadConThreadSelf("attr/sockcreate")
 }
 
 // PeerLabel retrieves the label of the client on the other side of a socket
 func PeerLabel(fd uintptr) (string, error) {
-	return peerLabel(int(fd)) //#nosec G115 -- ignore "integer overflow conversion uintptr -> int".
+	return impl.PeerLabel(fd)
 }
 
 // SetKeyLabel takes a process label and tells the kernel to assign the
@@ -200,67 +189,70 @@ func PeerLabel(fd uintptr) (string, error) {
 //
 // Only the thread group leader can set key label.
 func SetKeyLabel(label string) error {
-	return setKeyLabel(label)
+	return impl.SetKeyLabel(label)
 }
 
 // KeyLabel retrieves the current kernel keyring label setting
 func KeyLabel() (string, error) {
-	return keyLabel()
-}
-
-// Get returns the Context as a string
-func (c Context) Get() string {
-	return c.get()
+	return impl.KeyLabel()
 }
 
 // NewContext creates a new Context struct from the specified label
 func NewContext(label string) (Context, error) {
-	return newContext(label)
+	return impl.NewContext(label)
 }
 
 // ClearLabels clears all reserved labels
 func ClearLabels() {
-	clearLabels()
+	impl.ClearLabels()
 }
 
 // ReserveLabel reserves the MLS/MCS level component of the specified label.
+//
+// Deprecated: use [ReserveLabelV2] instead.
+func ReserveLabel(label string) {
+	_ = impl.ReserveLabel(label)
+}
+
+// ReserveLabelV2 reserves the MLS/MCS level component of the specified label.
 // Returns an error if the label can't be reserved.
-func ReserveLabel(label string) error {
-	return reserveLabel(label)
+func ReserveLabelV2(label string) error {
+	return impl.ReserveLabel(label)
 }
 
 // CheckLabel check the MLS/MCS level component of the specified label
 func CheckLabel(label string) error {
-	return checkLabel(label)
+	return impl.CheckLabel(label)
 }
 
 // MLSEnabled checks if MLS is enabled.
 func MLSEnabled() bool {
-	return isMLSEnabled()
+	return impl.MLSEnabled()
 }
 
-// EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+// EnforceMode returns the current SELinux mode (one of [Enforcing],
+// [Permissive], or [Disabled]).
 func EnforceMode() int {
-	return enforceMode()
+	return impl.EnforceMode()
 }
 
 // SetEnforceMode sets the current SELinux mode Enforcing, Permissive.
 // Disabled is not valid, since this needs to be set at boot time.
 func SetEnforceMode(mode int) error {
-	return setEnforceMode(mode)
+	return impl.SetEnforceMode(mode)
 }
 
 // DefaultEnforceMode returns the systems default SELinux mode Enforcing,
 // Permissive or Disabled. Note this is just the default at boot time.
 // EnforceMode tells you the systems current mode.
 func DefaultEnforceMode() int {
-	return defaultEnforceMode()
+	return impl.DefaultEnforceMode()
 }
 
 // ReleaseLabel un-reserves the MLS/MCS Level field of the specified label,
 // allowing it to be used by another process.
 func ReleaseLabel(label string) {
-	releaseLabel(label)
+	impl.ReleaseLabel(label)
 }
 
 // ROFileLabel returns the specified SELinux readonly file label.
@@ -268,7 +260,7 @@ func ReleaseLabel(label string) {
 // Deprecated: this (apparently) has no users and will be removed from the
 // future version of this package. Open a bug report if you use it.
 func ROFileLabel() string {
-	return roFileLabel()
+	return impl.ROFileLabel()
 }
 
 // KVMContainerLabels returns the default processLabel and mountLabel to be used
@@ -276,13 +268,13 @@ func ROFileLabel() string {
 //
 // Deprecated: use [KVMContainerLabel] instead.
 func KVMContainerLabels() (string, string) {
-	return kvmContainerLabels()
+	return impl.KVMContainerLabels()
 }
 
 // KVMContainerLabel returns the default process label to be used
 // for KVM containers by the calling process.
 func KVMContainerLabel() (string, error) {
-	return kvmContainerLabel()
+	return impl.KVMContainerLabel()
 }
 
 // InitContainerLabels returns the default processLabel and file labels to be
@@ -290,30 +282,33 @@ func KVMContainerLabel() (string, error) {
 //
 // Deprecated: use [InitContainerLabel] instead.
 func InitContainerLabels() (string, string) {
-	return initContainerLabels()
+	return impl.InitContainerLabels()
 }
 
 // InitContainerLabel returns the default process label to be used
 // for containers running an init system like systemd by the calling process.
 func InitContainerLabel() (string, error) {
-	return initContainerLabel()
+	return impl.InitContainerLabel()
 }
 
 // ContainerLabels returns an allocated processLabel and fileLabel to be used for
 // container labeling by the calling process.
+//
+// Deprecated: this (apparently) has no users and will be removed from the
+// future version of this package. Open a bug report if you use it.
 func ContainerLabels() (processLabel string, fileLabel string) {
-	return containerLabels()
+	return impl.ContainerLabels()
 }
 
 // SecurityCheckContext validates that the SELinux label is understood by the kernel
 func SecurityCheckContext(val string) error {
-	return securityCheckContext(val)
+	return impl.SecurityCheckContext(val)
 }
 
 // CopyLevel returns a label with the MLS/MCS level from src label replaced on
 // the dest label.
 func CopyLevel(src, dest string) (string, error) {
-	return copyLevel(src, dest)
+	return impl.CopyLevel(src, dest)
 }
 
 // Chcon changes the fpath file object to the SELinux label.
@@ -322,13 +317,13 @@ func CopyLevel(src, dest string) (string, error) {
 //
 // The fpath itself is guaranteed to be relabeled last.
 func Chcon(fpath string, label string, recurse bool) error {
-	return chcon(fpath, label, recurse)
+	return impl.Chcon(fpath, label, recurse)
 }
 
 // DupSecOpt takes an SELinux process label and returns security options that
 // can be used to set the SELinux Type and Level for future container processes.
 func DupSecOpt(src string) ([]string, error) {
-	return dupSecOpt(src)
+	return impl.DupSecOpt(src)
 }
 
 // DisableSecOpt returns a security opt that can be used to disable SELinux
@@ -341,7 +336,7 @@ func DisableSecOpt() []string {
 // Linux username. The username and security level is based on the
 // /etc/selinux/{SELINUXTYPE}/seusers file.
 func SEUserByName(username string) (seUser string, level string, err error) {
-	return getSeUserByName(username)
+	return impl.SEUserByName(username)
 }
 
 // GetDefaultContextWithLevel gets a single context for the specified SELinux user
@@ -351,12 +346,10 @@ func SEUserByName(username string) (seUser string, level string, err error) {
 // file and finally the global /etc/selinux/{SELINUXTYPE}/contexts/failsafe_context
 // file if no match can be found anywhere else.
 func GetDefaultContextWithLevel(user, level, scon string) (string, error) {
-	return getDefaultContextWithLevel(user, level, scon)
+	return impl.GetDefaultContextWithLevel(user, level, scon)
 }
 
 // PrivContainerMountLabel returns mount label for privileged containers
 func PrivContainerMountLabel() string {
-	// Make sure label is initialized.
-	_ = label("")
-	return privContainerMountLabel
+	return impl.PrivContainerMountLabel()
 }

--- a/internal/impl/selinux.go
+++ b/internal/impl/selinux.go
@@ -1,4 +1,4 @@
-package selinux
+package impl
 
 import (
 	"errors"
@@ -224,15 +224,8 @@ func ClearLabels() {
 }
 
 // ReserveLabel reserves the MLS/MCS level component of the specified label.
-//
-// Deprecated: use [ReserveLabelV2] instead.
-func ReserveLabel(label string) {
-	_ = reserveLabel(label)
-}
-
-// ReserveLabelV2 reserves the MLS/MCS level component of the specified label.
 // Returns an error if the label can't be reserved.
-func ReserveLabelV2(label string) error {
+func ReserveLabel(label string) error {
 	return reserveLabel(label)
 }
 
@@ -308,9 +301,6 @@ func InitContainerLabel() (string, error) {
 
 // ContainerLabels returns an allocated processLabel and fileLabel to be used for
 // container labeling by the calling process.
-//
-// Deprecated: this (apparently) has no users and will be removed from the
-// future version of this package. Open a bug report if you use it.
 func ContainerLabels() (processLabel string, fileLabel string) {
 	return containerLabels()
 }

--- a/internal/impl/selinux_linux.go
+++ b/internal/impl/selinux_linux.go
@@ -1,4 +1,4 @@
-package selinux
+package impl
 
 import (
 	"bufio"

--- a/internal/impl/selinux_linux.go
+++ b/internal/impl/selinux_linux.go
@@ -290,8 +290,8 @@ func openProcThreadSelf(subpath string, mode int) (*os.File, procfs.ProcThreadSe
 	return file, closer, nil
 }
 
-// Read the contents of /proc/thread-self/<fpath>.
-func readConThreadSelf(fpath string) (string, error) {
+// ReadConThreadSelf reads the contents of /proc/thread-self/<fpath>.
+func ReadConThreadSelf(fpath string) (string, error) {
 	in, closer, err := openProcThreadSelf(fpath, os.O_RDONLY|unix.O_CLOEXEC)
 	if err != nil {
 		return "", err
@@ -302,8 +302,8 @@ func readConThreadSelf(fpath string) (string, error) {
 	return readConFd(in)
 }
 
-// Write <val> to /proc/thread-self/<fpath>.
-func writeConThreadSelf(fpath, val string) error {
+// WriteConThreadSelf writes val to /proc/thread-self/<fpath>.
+func WriteConThreadSelf(fpath, val string) error {
 	if val == "" {
 		if !getEnabled() {
 			return nil
@@ -509,7 +509,7 @@ func lFileLabel(fpath string) (string, error) {
 }
 
 func setFSCreateLabel(label string) error {
-	return writeConThreadSelf("attr/fscreate", label)
+	return WriteConThreadSelf("attr/fscreate", label)
 }
 
 // pidLabel returns the SELinux label of the given pid, or an error.

--- a/internal/impl/selinux_linux_test.go
+++ b/internal/impl/selinux_linux_test.go
@@ -1,4 +1,4 @@
-package selinux
+package impl
 
 import (
 	"bufio"

--- a/internal/impl/selinux_stub.go
+++ b/internal/impl/selinux_stub.go
@@ -2,11 +2,11 @@
 
 package impl
 
-func readConThreadSelf(string) (string, error) {
+func ReadConThreadSelf(string) (string, error) {
 	return "", nil
 }
 
-func writeConThreadSelf(string, string) error {
+func WriteConThreadSelf(string, string) error {
 	return nil
 }
 

--- a/internal/impl/selinux_stub.go
+++ b/internal/impl/selinux_stub.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-package selinux
+package impl
 
 func readConThreadSelf(string) (string, error) {
 	return "", nil

--- a/internal/impl/selinux_stub_test.go
+++ b/internal/impl/selinux_stub_test.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-package selinux
+package impl
 
 import (
 	"testing"
@@ -46,7 +46,9 @@ func TestSELinuxStubs(t *testing.T) {
 
 	ClearLabels()
 
-	ReserveLabel(testLabel)
+	if err := ReserveLabel(testLabel); err != nil {
+		t.Error(err)
+	}
 	ReleaseLabel(testLabel)
 	if _, err := DupSecOpt(testLabel); err != nil {
 		t.Error(err)

--- a/internal/impl/xattrs_linux.go
+++ b/internal/impl/xattrs_linux.go
@@ -1,4 +1,4 @@
-package selinux
+package impl
 
 import (
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
~~Draft pending #262 merge.~~

The issue being solved is go-selinux is both a package for external consumption, as well as a package to be used by  go-selinux/label. Some of go-selinux APIs (say ContainerLabels) have only 1 user: label, and it needs to be internal.

The main idea is we can
 - use the functionality freely from both packages (go-selinux and go-selinux/label);
 - add or change the (internal) API however we want.
 
 TODO: identify more stuff that should be internal-only (like ContainerLabels).

----

1. go-selinux: move to internal/impl
    
    This moves (git mv) the whole package to under internal, with the
    minimal changes (package name only).
    
    This commit breaks git-bisect; this is done deliberately to show this is
    merely the moving files around. The next commit fixes things.

2. go-selinux: wire to ../internal/impl
    
    The only change in internal/impl is making ReadConThreadSelf and
    WriteConThreadSelf public.

3. label: switch to internal/impl