### PR TITLE
Fix label.InitLabels regression in v1.14.0; amend ReserveLabelV2 doc

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,20 +136,18 @@ jobs:
           fi
 
       - name: "make test"
-        continue-on-error: true
         run: lima make -C /tmp/selinux test
 
       - name: "32-bit test"
-        continue-on-error: true
         run: lima make -C /tmp/selinux GOARCH=386 test
 
       # https://github.com/opencontainers/selinux/issues/222
       # https://github.com/opencontainers/selinux/issues/225
       - name: "racy test"
-        continue-on-error: true
         run: lima bash -c 'cd /tmp/selinux && go test -timeout 10m -count 100000 ./go-selinux'
 
       - name: "Show AVC denials"
+        if: always()
         run: lima sudo ausearch -m AVC,USER_AVC || true
 
   all-done:

--- a/go-selinux/label/label_linux.go
+++ b/go-selinux/label/label_linux.go
@@ -22,8 +22,13 @@ var ErrIncompatibleLabel = errors.New("bad SELinux option: z and Z can not be us
 
 // InitLabels returns the process label and file labels to be used within
 // the container.  A list of options can be passed into this function to alter
-// the labels.  The labels returned will include a random MCS String, that is
-// guaranteed to be unique.
+// the labels.
+//
+// Unless the "level" option is provided (to set a custom level), the labels
+// returned will include a random MCS string guaranteed to be unique in the
+// scope of the process using this package. If the "level" option is provided,
+// the custom level set is reserved but not checked to be unique.
+//
 // If the disabled flag is passed in, the process label will not be set, but the mount label will be set
 // to the container_file label with the maximum category. This label is not usable by any confined label.
 func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
@@ -70,9 +75,11 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 	if p := pcon.Get(); p != processLabel {
 		if pcon["level"] != mcsLevel {
 			selinux.ReleaseLabel(processLabel)
-		}
-		if err := selinux.ReserveLabelV2(p); err != nil {
-			return "", "", err
+			// Ignore ErrMCSAlreadyExists as label is user-specified and might be
+			// already reserved (e.g. when containers in a pod use the same label).
+			if err := selinux.ReserveLabelV2(p); err != nil && !errors.Is(err, selinux.ErrMCSAlreadyExists) {
+				return "", "", err
+			}
 		}
 		processLabel = p
 	}

--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -127,3 +127,15 @@ func TestFileLabel(t *testing.T) {
 		t.Fatalf("InitLabels(filetype) failed: %v", err)
 	}
 }
+
+func TestInitLabelsTypeOverrideKeepsMCS(t *testing.T) {
+	needSELinux(t)
+
+	// Override only `type:` — level (MCS) must stay the same and
+	// must not trip ErrMCSAlreadyExists.
+	plabel, _, err := InitLabels([]string{"type:container_init_t"})
+	if err != nil {
+		t.Fatalf("InitLabels with type override failed: %v", err)
+	}
+	selinux.ReleaseLabel(plabel)
+}

--- a/go-selinux/label/label_linux_test.go
+++ b/go-selinux/label/label_linux_test.go
@@ -37,6 +37,7 @@ func TestInit(t *testing.T) {
 
 	testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
 	plabel, mlabel, err = InitLabels(testUser)
+	selinux.ReleaseLabel(plabel)
 	if err != nil {
 		t.Fatalf("InitLabels(user) failed: %v", err)
 	}
@@ -118,6 +119,7 @@ func TestFileLabel(t *testing.T) {
 
 	testUser := []string{"filetype:test_file_t", "level:s0:c1,c15"}
 	_, mlabel, err := InitLabels(testUser)
+	selinux.ReleaseLabel(mlabel)
 	if err != nil {
 		t.Fatalf("InitLabels(user) failed: %v", err)
 	}

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -232,6 +232,10 @@ func ReserveLabel(label string) {
 
 // ReserveLabelV2 reserves the MLS/MCS level component of the specified label.
 // Returns an error if the label can't be reserved.
+//
+// Callers that are intentionally reusing an existing level/MCS (e.g. multiple
+// container in a pod sharing a label) may safely ignore [ErrMCSAlreadyExists]
+// error.
 func ReserveLabelV2(label string) error {
 	return reserveLabel(label)
 }


### PR DESCRIPTION
1. ci: fix ignoring test failures on lima
    
    Commit c826d9e introduced a regression -- if make test is failed, the job succeeds.
    
    The fix is to
     - not use continue-on-error (which makes the test succeed);
     - use "if: always()" for the step we want to run even on failure.

2. label: fix tests
    
    The two tests (TestInit and TestFileLabel) try to reserve the same MCS
    label (`level:s0:c1,c15`) without releasing it, and so the second test
    fails with ErrMCSAlreadyExists (as it should, since we are using
    selinux.ReserveLabelV2 which can return errors):
    
    > === RUN   TestFileLabel
    >     label_linux_test.go:122: InitLabels(user) failed: MCS label already exists
    
    Fix tests by releasing the label.

3. label: fix ErrMCSAlreadyExists from InitLabels
    
    The hardening done to label.InitLabels in commit 97d2a7c ("Add
    ReserveLabelV2, deprecate ReserveLabel") revealed the internal issue:
    we try to reserve label which was already reserved. As a result,
    InitLabels can return ErrMCSAlreadyExists when it should not.
    
    Fix by only reserving a label if its MCS ("level") differs from the one
    returned by ContainerLabels.
    
    Add a test (which fails before the fix).

