### PR TITLE
README: rm travis, add gha badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # selinux
 
-[![GoDoc](https://godoc.org/github.com/opencontainers/selinux?status.svg)](https://godoc.org/github.com/opencontainers/selinux) [![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/selinux)](https://goreportcard.com/report/github.com/opencontainers/selinux) [![Build Status](https://travis-ci.org/opencontainers/selinux.svg?branch=master)](https://travis-ci.org/opencontainers/selinux)
+[![Go Reference](https://pkg.go.dev/badge/github.com/opencontainers/selinux.svg)](https://pkg.go.dev/github.com/opencontainers/selinux)
+[![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/selinux)](https://goreportcard.com/report/github.com/opencontainers/selinux)
+[![validate](https://github.com/opencontainers/selinux/actions/workflows/validate.yml/badge.svg)](https://github.com/opencontainers/selinux/actions/workflows/validate.yml)
 
 Common SELinux package used across the container ecosystem.
 


### PR DESCRIPTION
We've switched away from Travis CI in 2021 (commit 9612a36) so perhaps it's time to remove the badge.

Add a GHA validate badge (the only one we have).

While at it, split the long line (does not result in any layout changes).