### PR TITLE
ci: set timeout for vm jobs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,7 +92,7 @@ jobs:
         run: make TESTFLAGS="${{ matrix.race }}" test
 
   vm:
-    name: "VM"
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In some cases VM jobs got stuck (or lost), and with the default timeout of 6 hours it's inconvenient.

At most, a vm job takes ~6 minutes now. Set the timeout to 20.
