### PR TITLE
ReserveLabelV2: ignore labels without MCS

### DIFF
--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -246,6 +246,7 @@ func ReserveLabel(label string) {
 }
 
 // ReserveLabelV2 reserves the MLS/MCS level component of the specified label.
+// Labels without MLS/MCS category component (":c") are ignored.
 // Returns an error if the label can't be reserved.
 //
 // Callers that are intentionally reusing an existing level/MCS (e.g. multiple

--- a/go-selinux/selinux_linux.go
+++ b/go-selinux/selinux_linux.go
@@ -890,8 +890,10 @@ func defaultEnforceMode() int {
 	return Disabled
 }
 
+// mcsAdd reserves a level. If the argument is empty or does not contain
+// MCS/MLS category component (no ":c"), it is ignored.
 func mcsAdd(mcs string) error {
-	if mcs == "" {
+	if !strings.Contains(mcs, ":c") {
 		return nil
 	}
 	state.Lock()

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -926,6 +926,15 @@ fake_r:fake_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 	})
 }
 
+func TestReserveLabelNoMCS(t *testing.T) {
+	const label = "system_u:system_r:container_runtime_t:s0"
+
+	_ = ReserveLabelV2(label)
+	if err := ReserveLabelV2(label); err != nil {
+		t.Errorf("repeated ReserveLabelV2(%q): want nil, got %v", label, err)
+	}
+}
+
 func BenchmarkChcon(b *testing.B) {
 	file, err := filepath.Abs(os.Args[0])
 	if err != nil {


### PR DESCRIPTION
The whole point of ReserveLabelV2 is to ensure the MCS labels are
unique. So, if called with a label without MCS component, it should
do nothing. Before this patch, it reserves something like "s0".


Add a test case (which fails without the fix).

Inspired by https://github.com/cri-o/cri-o/pull/9955#issuecomment-4513640027